### PR TITLE
ffmpeg_patches: add amfenc delay/buffering fix

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -228,6 +228,7 @@ jobs:
         run: |
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/01-idr-on-amf.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-amf-color-fixes.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
+++ b/ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
@@ -1,0 +1,43 @@
+From 8b0966a3723a05d29810b116454a1eb94e15a0b1 Mon Sep 17 00:00:00 2001
+From: Conn O'Griofa <connogriofa@gmail.com>
+Date: Thu, 24 Nov 2022 06:34:48 +0000
+Subject: [PATCH] amfenc: disable buffering & blocking delay in IPP mode
+
+When realtime encoding is required, the HW queue and arbitrary
+1ms sleep during blocking introduces unnecessary latency, especially
+in low FPS situations such as streaming desktop content at a variable
+framerate.
+
+Resolve by disabling buffering and blocking delay if no B-frames are
+requested, as is typical for zero latency streaming use cases.
+---
+ libavcodec/amfenc.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/amfenc.c b/libavcodec/amfenc.c
+index fb23ed738c..c452a0fd5b 100644
+--- a/libavcodec/amfenc.c
++++ b/libavcodec/amfenc.c
+@@ -219,7 +219,7 @@ static int amf_init_context(AVCodecContext *avctx)
+     av_unused int ret;
+ 
+     ctx->hwsurfaces_in_queue = 0;
+-    ctx->hwsurfaces_in_queue_max = 16;
++    ctx->hwsurfaces_in_queue_max = avctx->max_b_frames > 0 ? 16 : 0; // avoid buffering frames if no B frames are in use
+ 
+     // configure AMF logger
+     // the return of these functions indicates old state and do not affect behaviour
+@@ -769,7 +769,9 @@ int ff_amf_receive_packet(AVCodecContext *avctx, AVPacket *avpkt)
+             }
+         } else if (ctx->delayed_surface != NULL || ctx->delayed_drain || (ctx->eof && res_query != AMF_EOF) || (ctx->hwsurfaces_in_queue >= ctx->hwsurfaces_in_queue_max)) {
+             block_and_wait = 1;
+-            av_usleep(1000); // wait and poll again
++            if (avctx->max_b_frames > 0) {
++                av_usleep(1000); // wait and poll again
++            }
+         }
+     } while (block_and_wait);
+ 
+-- 
+2.37.2
+


### PR DESCRIPTION
## Description
This resolves the issue in which the last captured frame is delayed by 1ms, which
is especially noticeable in low framerate content (such as desktop streaming)
on the amfenc encoder.

### Issues Fixed or Closed
Fixes all reports related to delay with callback capture using the amfenc encoder:
* https://github.com/LizardByte/Sunshine/issues/122
* https://github.com/LizardByte/Sunshine/issues/387
* https://github.com/LizardByte/Sunshine/issues/412

N.B. nvenc also experiences delay that is reported in some of the above issues. For those cases, it is resolved via a separate PR: https://github.com/LizardByte/Sunshine/pull/507

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
