### PR TITLE
ffmpeg: disable iconv support on all targets

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -217,6 +217,7 @@ jobs:
             --ld="g++" \
             --bindir="$root_path/bin" \
             --disable-all \
+            --disable-iconv \
             --enable-avcodec \
             --enable-gpl \
             --enable-libx264 \


### PR DESCRIPTION
## Description
Disable `iconv` in ffmpeg builds. Only needed for subtitle rendering in decoders which is never needed on Sunshine. Resolves linker errors on MacOS.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
