### PR TITLE
Disable autodetect, pin to ubuntu 20

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - os_type: linux
-            os: ubuntu-20.04 # Pinned for now until all platforms moved to 22.04
+            os: ubuntu-20.04  # Pinned until all platforms moved to 22.04
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles
@@ -225,8 +225,8 @@ jobs:
             --disable-autodetect \
             --disable-iconv \
             --enable-avcodec \
-            --enable-gpl \
             --enable-encoder=libx264,libx265 \
+            --enable-gpl \
             --enable-libx264 \
             --enable-libx265 \
             --enable-static \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -20,25 +20,28 @@ jobs:
       matrix:
         include:
           - os_type: linux
-            os: ubuntu-22.04
+            os: ubuntu-20.04 # Pinned for now until all platforms moved to 22.04
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles
             ffmpeg_extras: |
               --enable-amf \
+              --enable-cuda \
+              --enable-cuda_llvm \
               --enable-encoder=h264_amf,hevc_amf \
               --enable-encoder=h264_nvenc,hevc_nvenc \
               --enable-encoder=h264_vaapi,hevc_vaapi \
-              --enable-encoder=libx264,libx265 \
+              --enable-ffnvcodec \
               --enable-nvenc \
-              --enable-vaapi
+              --enable-v4l2_m2m \
+              --enable-vaapi \
+              --enable-vdpau
           - os_type: macos
             os: macos-11
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
             ffmpeg_extras: |
-              --enable-encoder=libx264,libx265 \
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox \
               --enable-videotoolbox
           - os_type: windows
@@ -48,10 +51,12 @@ jobs:
             cmake_generator: MSYS Makefiles
             ffmpeg_extras: |
               --enable-amf \
+              --enable-cuda \
+              --enable-d3d11va \
               --enable-encoder=h264_amf,hevc_amf \
-              --enable-encoder=libx264,libx265 \
               --enable-encoder=h264_mf,hevc_mf \
               --enable-encoder=h264_nvenc,hevc_nvenc \
+              --enable-ffnvcodec \
               --enable-nvenc \
               --enable-mediafoundation
     runs-on: ${{ matrix.os }}
@@ -217,8 +222,11 @@ jobs:
             --ld="g++" \
             --bindir="$root_path/bin" \
             --disable-all \
+            --disable-autodetect \
+            --disable-iconv \
             --enable-avcodec \
             --enable-gpl \
+            --enable-encoder=libx264,libx265 \
             --enable-libx264 \
             --enable-libx265 \
             --enable-static \


### PR DESCRIPTION
## Description
1) Disable autodetect and iconv to reduce library conflicts from prebuilts
2) Pin build to Ubuntu 20.04 to resolve linking of libmvec/libm and libpthread when built on 22.04 then later used on 20.04. This is due to those libraries being moved around: https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread


### Issues Fixed or Closed
N/A - progress towards ffmpeg5 upgrade


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
