### PR TITLE
macOS aarch64

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -32,6 +32,7 @@ jobs:
               --enable-encoder=h264_nvenc,hevc_nvenc
               --enable-encoder=h264_vaapi,hevc_vaapi
               --enable-ffnvcodec
+              --enable-libx265
               --enable-nvenc
               --enable-v4l2_m2m
               --enable-vaapi
@@ -50,6 +51,7 @@ jobs:
               --enable-encoder=h264_nvenc,hevc_nvenc
               --enable-encoder=h264_vaapi,hevc_vaapi
               --enable-ffnvcodec
+              --enable-libx265
               --enable-nvenc
               --enable-v4l2_m2m
               --enable-vaapi
@@ -57,6 +59,15 @@ jobs:
           - os_type: macos
             os: macos-11
             arch: x86_64
+            shell: bash
+            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
+            ffmpeg_extras: >-
+              --enable-encoder=h264_videotoolbox,hevc_videotoolbox
+              --enable-videotoolbox
+              --enable-libx265
+          - os_type: macos
+            os: macos-11
+            arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
             ffmpeg_extras: >-
@@ -75,6 +86,7 @@ jobs:
               --enable-encoder=h264_mf,hevc_mf
               --enable-encoder=h264_nvenc,hevc_nvenc
               --enable-ffnvcodec
+              --enable-libx265
               --enable-nvenc
               --enable-mediafoundation
     runs-on: ${{ matrix.os }}
@@ -86,21 +98,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Checkout destination branch
-        uses: actions/checkout@v3
-        with:
-          ref: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          path: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
-          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
-
-      - name: Setup Dependencies Unix
-        if: ${{ matrix.os_type != 'windows' }}
+      - name: Setup Dependencies Linux
+        if: ${{ matrix.os_type == 'linux' }}
         run: |
           echo "::group::${{ matrix.os_type }} dependencies"
-          if [[ ${{ matrix.os }} == "ubuntu-18.04" ]]; then
-            dist="bionic"
-          elif [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
+          if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
             dist="focal"
           elif [[ ${{ matrix.os }} == "ubuntu-22.04" ]]; then
             dist="jammy"
@@ -137,38 +139,52 @@ jobs:
             sudo cat /etc/apt/sources.list
           fi
 
-          if [[ ${{ matrix.os_type }} == "linux" ]]; then
-            sudo apt-get update -qq && sudo apt-get -y install \
+          sudo apt-get update -qq && sudo apt-get -y install \
+            autoconf \
+            automake \
+            build-essential \
+            cmake \
+            git-core \
+            libass-dev \
+            libfreetype6-dev \
+            libgnutls28-dev \
+            libmp3lame-dev \
+            libnuma-dev \
+            libopus-dev \
+            libsdl2-dev \
+            libtool \
+            libva-dev:$package_arch \
+            libvdpau-dev \
+            libvorbis-dev \
+            libxcb1-dev \
+            libxcb-shm0-dev \
+            libxcb-xfixes0-dev \
+            meson \
+            nasm \
+            ninja-build \
+            pkg-config \
+            texinfo \
+            wget \
+            yasm \
+            zlib1g-dev
+          echo "::endgroup::"
+
+          if [[ ${{ matrix.arch }} == "aarch64" ]]; then
+            echo "::group::${{ matrix.os_type }}-${{ matrix.arch }} dependencies"
+            sudo apt-get -y install \
+              binutils-${{ matrix.host }} \
+              g++-${{ matrix.host }} \
+              gcc-${{ matrix.host }}
+            echo "::endgroup::"
+          fi
+
+      - name: Setup Dependencies macOS
+        if: ${{ matrix.os_type == 'macos' }}
+        run: |
+            brew install \
               autoconf \
               automake \
-              build-essential \
               cmake \
-              git-core \
-              libass-dev \
-              libfreetype6-dev \
-              libgnutls28-dev \
-              libmp3lame-dev \
-              libnuma-dev \
-              libopus-dev \
-              libsdl2-dev \
-              libtool \
-              libva-dev:$package_arch \
-              libvdpau-dev \
-              libvorbis-dev \
-              libxcb1-dev \
-              libxcb-shm0-dev \
-              libxcb-xfixes0-dev \
-              meson \
-              nasm \
-              ninja-build \
-              pkg-config \
-              texinfo \
-              wget \
-              yasm \
-              zlib1g-dev
-          elif [[ ${{ matrix.os_type }} == "macos" ]]; then
-            brew install \
-              automake \
               fdk-aac \
               git \
               lame \
@@ -178,6 +194,7 @@ jobs:
               libvpx \
               nasm \
               opus \
+              pkg-config \
               sdl \
               shtool \
               texi2html \
@@ -185,17 +202,6 @@ jobs:
               wget \
               yasm \
               xvid
-          fi
-          echo "::endgroup::"
-
-          if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
-            echo "::group::${{ matrix.os_type }}-${{ matrix.arch }} dependencies"
-            sudo apt-get -y install \
-              binutils-${{ matrix.host }} \
-              g++-${{ matrix.host }} \
-              gcc-${{ matrix.host }}
-            echo "::endgroup::"
-          fi
 
       - name: Setup Dependencies Windows
         if: ${{ matrix.os_type == 'windows' }}
@@ -230,9 +236,9 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-idr-on-amf.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
 
-      - name: Setup cross compilation
+      - name: Setup linux cross compilation
         id: cross
-        if: ${{ matrix.arch == 'aarch64' }}
+        if: ${{ matrix.os_type == 'linux' && matrix.arch == 'aarch64' }}
         run: |
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
 
@@ -254,13 +260,17 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::configure extra flags for cross compilation"
+
+          extra_configure=""
+          if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-${{ matrix.os_type }}
           --cross-prefix=${CCPREFIX}
           VAREOF
           )
-          if [[ ${{ matrix.arch }} != "aarch64" ]]; then
-            extra_configure=""
+          elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+            CC="clang -arch arm64"
+            extra_configure="--arch=arm64"
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -285,6 +295,7 @@ jobs:
           echo "::endgroup::"
 
       - name: libx265
+        if: ${{ matrix.os_type != 'macos' && matrix.arch != 'aarch64' }}
         env:
           root_path: ${{ steps.root.outputs.root_path }}
           CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
@@ -350,6 +361,8 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::configure extra flags for cross compilation"
+          extra_configure=""
+          if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cross-prefix=${CCPREFIX}
@@ -357,8 +370,13 @@ jobs:
           --target-os=${{ matrix.os_type }}
           VAREOF
           )
-          if [[ ${{ matrix.arch }} != "aarch64" ]]; then
-            extra_configure=""
+          elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          CC='clang -arch arm64'
+          extra_configure=$(cat <<VAREOF
+          --arch=${{ matrix.arch }}
+          --enable-cross-compile
+          VAREOF
+          )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -382,7 +400,6 @@ jobs:
             --enable-encoder=libx264,libx265 \
             --enable-gpl \
             --enable-libx264 \
-            --enable-libx265 \
             --enable-static \
             --enable-swscale \
             --pkg-config=pkg-config \
@@ -424,6 +441,14 @@ jobs:
         run: |
           echo "date=$(date +'%Y-%m-%d')"
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Checkout destination branch
+        uses: actions/checkout@v3
+        with:
+          ref: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
+          path: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
+          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
+          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
 
       - name: Prepare dependency branch
         run: |

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -409,7 +409,8 @@ jobs:
           --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
-          --cross-prefix=arm64-apple-darwin-
+          --as=$AS
+          --ar=ar
           --target-os=darwin
           --enable-cross-compile
           --enable-pic

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Dependencies Unix
         if: ${{ matrix.os_type != 'windows' }}
         run: |
-          echo "::group::${{ matrix.os_type }} dependencies"
+          echo "::group::${{ matrix.os_type }} dependencies prep"
           if [[ ${{ matrix.os }} == "ubuntu-18.04" ]]; then
             dist="bionic"
           elif [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
@@ -134,9 +134,10 @@ jobs:
           deb [arch=$package_arch] $mirror $dist-security multiverse
           VAREOF
           )
-
+          echo "::endgroup::"
 
           if [[ ${{ matrix.os_type }} == "linux" ]]; then
+            echo "::group::linux dependencies"
             if [[ $package_arch != "amd64" ]]; then
               # fix original sources
               sudo sed -i -e "s#deb http#deb [arch=amd64] http#g" /etc/apt/sources.list
@@ -176,17 +177,16 @@ jobs:
               wget \
               yasm \
               zlib1g-dev
-            echo "::endgroup::"
 
             if [[ ${{ matrix.arch }} == "aarch64" ]]; then
-              echo "::group::${{ matrix.os_type }}-${{ matrix.arch }} dependencies"
               sudo apt-get -y install \
                 binutils-${{ matrix.host }} \
                 g++-${{ matrix.host }} \
                 gcc-${{ matrix.host }}
-              echo "::endgroup::"
             fi
+            echo "::endgroup::"
           elif [[ ${{ matrix.os_type }} == "macos" ]]; then
+            echo "::group::macos dependencies"
             brew install \
               automake \
               fdk-aac \
@@ -205,6 +205,7 @@ jobs:
               wget \
               yasm \
               xvid
+            echo "::endgroup::"
           fi
 
       - name: Setup Dependencies Windows
@@ -264,7 +265,6 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::configure extra flags for cross compilation"
-
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure=$(cat <<VAREOF

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -426,9 +426,10 @@ jobs:
             --disable-autodetect \
             --disable-iconv \
             --enable-avcodec \
-            --enable-encoder=libx264 \
+            --enable-encoder=libx264,libx265 \
             --enable-gpl \
             --enable-libx264 \
+            --enable-libx265 \
             --enable-static \
             --enable-swscale \
             --pkg-config=pkg-config \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -248,8 +248,7 @@ jobs:
           if [[ ${{ matrix.os_type }} == 'linux' ]]; then
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
           else
-          CFLAGS="-arch arm64 -target ${{ matrix.host }} -march=armv8"
-          echo "CFLAGS=${CFLAGS}" >> $GITHUB_OUTPUT
+          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8" >> $GITHUB_OUTPUT
           fi
 
       - name: amf
@@ -278,8 +277,8 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          export CC="clang"
-          export CFLAGS=${{ steps.cross.outputs.CFLAGS }}
+          CC="clang"
+          CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -320,8 +319,8 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          export CFLAGS=${{ steps.cross.outputs.CFLAGS }}
-          export CXXFLAGS="-std=c++11 ${CFLAGS}"
+          CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          CXXFLAGS="-std=c++11 ${CFLAGS}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DENABLE_ASSEMBLY=0
@@ -397,9 +396,9 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          export CFLAGS=${{ steps.cross.outputs.CFLAGS }}
-          export CXXFLAGS="-std=c++11 ${CFLAGS}"
-          export LDFLAGS="${CFLAGS} -lc++"
+          CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          CXXFLAGS="-std=c++11 ${CFLAGS}"
+          LDFLAGS="${CFLAGS} -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=aarch64
           --cc=clang

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -69,11 +69,11 @@ jobs:
           #     --enable-videotoolbox
           #     --enable-libx265
           - os_type: macos
-            os: macos-11
+            os: macos-12
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
-            host: arm64-apple-darwin
+            host: aarch64-apple-darwin
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
               --enable-videotoolbox
@@ -103,11 +103,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Checkout destination branch
+        uses: actions/checkout@v3
+        with:
+          ref: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
+          path: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
+          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
+          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
+
       - name: Setup Dependencies Linux
         if: ${{ matrix.os_type == 'linux' }}
         run: |
           echo "::group::${{ matrix.os_type }} dependencies"
-          if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
+          if [[ ${{ matrix.os }} == "ubuntu-18.04" ]]; then
+            dist="bionic"
+          elif [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
             dist="focal"
           elif [[ ${{ matrix.os }} == "ubuntu-22.04" ]]; then
             dist="jammy"
@@ -207,12 +217,6 @@ jobs:
               wget \
               yasm \
               xvid
-            
-            which llvm-gcc || true
-            which clang || true
-            which ar || true
-            which llvm-ar || true
-            which ld || true
 
       - name: Setup Dependencies Windows
         if: ${{ matrix.os_type == 'windows' }}
@@ -281,9 +285,9 @@ jobs:
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
-          CFLAGS="-target aarch64-apple-darwin"
+          CFLAGS="-target ${{ matrix.host }}"
           extra_configure=$(cat <<VAREOF
-          --host=arm64-darwin
+          --host=${{ matrix.arch }}-darwin
           VAREOF
           )
           fi
@@ -293,7 +297,6 @@ jobs:
           echo "::group::configure"
           PATH="$root_path/bin:$PATH" \
             PKG_CONFIG_PATH="$root_path/ffmpeg_build/lib/pkgconfig" \
-            $test_env \
             ./configure \
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
@@ -371,7 +374,6 @@ jobs:
           root_path: ${{ steps.root.outputs.root_path }}
         working-directory: ffmpeg_sources/ffmpeg
         run: |
-          set -o xtrace
           echo "::group::configure options"
           ./configure --help || true  # this command has a non zero exit status, but we should continue anyway
           echo "::endgroup::"
@@ -387,13 +389,13 @@ jobs:
           --target-os=${{ matrix.os_type }}
           VAREOF
           )
-          targetos=${{ matrix.host }}
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          targetos=darwin
           CC="clang"
-          CFLAGS="-target aarch64-apple-darwin"
+          CPU="apple-m1"
+          MORE_C_FLAGS="-target=${{ matrix.host }} -march=$CPU"
           extra_configure=$(cat <<VAREOF
-          --arch=aarch64
+          --arch=${{ matrix.arch }}
+          --cpu=$CPU
           --enable-cross-compile
           --target-os=darwin
           VAREOF
@@ -406,20 +408,20 @@ jobs:
           echo "::group::configure"
           set +e  # do not fail
           PATH="$root_path/bin:$PATH" \
-            PKG_CONFIG_PATH="$nvenc_path:$root_path/ffmpeg_build/lib/pkgconfig:/usr/lib/$targetos/pkgconfig" \
+            PKG_CONFIG_PATH="$nvenc_path:$root_path/ffmpeg_build/lib/pkgconfig:/usr/lib/${{ matrix.host }}/pkgconfig" \
             ./configure \
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
             --pkg-config-flags="--static" \
-            --extra-cflags="-I$root_path/ffmpeg_build/include" \
-            --extra-ldflags="-L$root_path/ffmpeg_build/lib" \
+            --extra-cflags="-I$root_path/ffmpeg_build/include ${MORE_C_FLAGS}" \
+            --extra-ldflags="-L$root_path/ffmpeg_build/lib ${MORE_C_FLAGS}" \
             --extra-libs="-lpthread -lm" \
             --bindir="$root_path/bin" \
             --disable-all \
             --disable-autodetect \
             --disable-iconv \
             --enable-avcodec \
-            --enable-encoder=libx264 \
+            --enable-encoder=libx264,libx265 \
             --enable-gpl \
             --enable-libx264 \
             --enable-static \
@@ -446,7 +448,6 @@ jobs:
           echo "::group::make install"
           make install
           echo "::endgroup::"
-          set +o xtrace
 
           echo "::group::copy license"
           cp ./COPYING.GPLv2 $root_path/ffmpeg_build/LICENSE
@@ -464,14 +465,6 @@ jobs:
         run: |
           echo "date=$(date +'%Y-%m-%d')"
           echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Checkout destination branch
-        uses: actions/checkout@v3
-        with:
-          ref: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          path: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
-          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
 
       - name: Prepare dependency branch
         run: |

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -67,7 +67,7 @@ jobs:
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
-            host: aarch64-apple-darwin
+            host: arm64-apple-macosx
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
               --enable-videotoolbox
@@ -274,7 +274,8 @@ jobs:
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
-          CFLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
+          # CFLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
+          CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -390,8 +391,6 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          MORE_C_FLAGS="--target=${{ matrix.host }} -arch=${{ matrix.arch }}"
-          MORE_LD_FLAGS="-arch=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang
@@ -411,8 +410,8 @@ jobs:
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
             --pkg-config-flags="--static" \
-            --extra-cflags="-I$root_path/ffmpeg_build/include --target=${{ matrix.host }} -arch=${{ matrix.arch }}" \
-            --extra-ldflags="-L$root_path/ffmpeg_build/lib -arch=${{ matrix.arch }}" \
+            --extra-cflags="-I$root_path/ffmpeg_build/include -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic" \
+            --extra-ldflags="-L$root_path/ffmpeg_build/lib -arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx" \
             --extra-libs="-lpthread -lm" \
             --bindir="$root_path/bin" \
             --disable-all \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -391,13 +391,13 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
-          --cc=clang
-          --extra-cflags="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          --cxx=clang++
-          --extra-cxxflags="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          --extra-ldflags="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx"
+          --cc="clang"
+          --cxx="clang++"
           --enable-cross-compile
           --enable-pic
           VAREOF

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -277,7 +277,7 @@ jobs:
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
-          CFLAGS="--target=${{ matrix.host }}"
+          CFLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -306,7 +306,7 @@ jobs:
           echo "::endgroup::"
 
       - name: libx265
-        # if: ${{ matrix.os_type != 'macos' || matrix.arch != 'aarch64' }}
+        if: ${{ matrix.os_type != 'macos' || matrix.arch != 'aarch64' }}
         env:
           root_path: ${{ steps.root.outputs.root_path }}
           CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
@@ -324,11 +324,11 @@ jobs:
           CPU="apple-m1"
           TARGET="${{ matrix.host }}"
           ARCH="${{ matrix.arch }}"
-          CLFAGS="--target=${{ matrix.host }}"
-          CXXFLAGS="--target=${{ matrix.host }}"
-          LDFLAGS="--target=${{ matrix.host }}"
+          CFLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
+          CXXFLAGS="--target=${{ matrix.host }}  -march=${{ matrix.arch }}"
+          LDFLAGS="--target=${{ matrix.host }}  -march=${{ matrix.arch }}"
           CMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
-          CMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }}"
+          CMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DCMAKE_SYSTEM_PROCESSOR="$CPU"
@@ -408,7 +408,6 @@ jobs:
           --target-os=darwin
           VAREOF
           )
-          # --cross-prefix="$root_path/ffmpeg_build"
           fi
           echo "$extra_configure"
           echo "::endgroup::"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -306,7 +306,6 @@ jobs:
           echo "::endgroup::"
 
       - name: libx265
-        if: ${{ matrix.os_type != 'macos' || matrix.arch != 'aarch64' }}
         env:
           root_path: ${{ steps.root.outputs.root_path }}
           CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Dependencies Unix
         if: ${{ matrix.os_type != 'windows' }}
         run: |
-          echo "::group::${{ matrix.os_type }} dependencies prep"
+          echo "::group::dependencies prep"
           if [[ ${{ matrix.os }} == "ubuntu-18.04" ]]; then
             dist="bionic"
           elif [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
@@ -411,8 +411,8 @@ jobs:
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
             --pkg-config-flags="--static" \
-            --extra-cflags="-I$root_path/ffmpeg_build/include ${MORE_C_FLAGS}" \
-            --extra-ldflags="-L$root_path/ffmpeg_build/lib ${MORE_LD_FLAGS}" \
+            --extra-cflags="-I$root_path/ffmpeg_build/include --target=${{ matrix.host }} -arch=${{ matrix.arch }}" \
+            --extra-ldflags="-L$root_path/ffmpeg_build/lib -arch=${{ matrix.arch }}" \
             --extra-libs="-lpthread -lm" \
             --bindir="$root_path/bin" \
             --disable-all \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -19,81 +19,73 @@ jobs:
       fail-fast: false  # false to test all, true to fail entire job if any fail
       matrix:
         include:
-          # - os_type: linux
-          #   os: ubuntu-20.04  # Pinned until all platforms moved to 22.04
-          #   arch: x86_64
-          #   shell: bash
-          #   cmake_generator: Unix Makefiles
-          #   ffmpeg_extras: >-
-          #     --enable-amf
-          #     --enable-cuda
-          #     --enable-cuda_llvm
-          #     --enable-encoder=h264_amf,hevc_amf
-          #     --enable-encoder=h264_nvenc,hevc_nvenc
-          #     --enable-encoder=h264_vaapi,hevc_vaapi
-          #     --enable-encoder=libx265
-          #     --enable-ffnvcodec
-          #     --enable-libx265
-          #     --enable-nvenc
-          #     --enable-v4l2_m2m
-          #     --enable-vaapi
-          #     --enable-vdpau
-          # - os_type: linux
-          #   os: ubuntu-22.04
-          #   arch: aarch64
-          #   shell: bash
-          #   cmake_generator: Unix Makefiles
-          #   host: aarch64-linux-gnu
-          #   ffmpeg_extras: >-
-          #     --enable-amf
-          #     --enable-cuda
-          #     --enable-cuda_llvm
-          #     --enable-encoder=h264_amf,hevc_amf
-          #     --enable-encoder=h264_nvenc,hevc_nvenc
-          #     --enable-encoder=h264_vaapi,hevc_vaapi
-          #     --enable-encoder=libx265
-          #     --enable-ffnvcodec
-          #     --enable-libx265
-          #     --enable-nvenc
-          #     --enable-v4l2_m2m
-          #     --enable-vaapi
-          #     --enable-vdpau
-          # - os_type: macos
-          #   os: macos-11
-          #   arch: x86_64
-          #   shell: bash
-          #   cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
-          #   ffmpeg_extras: >-
-          #     --enable-encoder=h264_videotoolbox,hevc_videotoolbox
-          #     --enable-encoder=libx265
-          #     --enable-videotoolbox
-          #     --enable-libx265
+          - os_type: linux
+            os: ubuntu-20.04  # Pinned until all platforms moved to 22.04
+            arch: x86_64
+            shell: bash
+            cmake_generator: Unix Makefiles
+            ffmpeg_extras: >-
+              --enable-amf
+              --enable-cuda
+              --enable-cuda_llvm
+              --enable-encoder=h264_amf,hevc_amf
+              --enable-encoder=h264_nvenc,hevc_nvenc
+              --enable-encoder=h264_vaapi,hevc_vaapi
+              --enable-ffnvcodec
+              --enable-nvenc
+              --enable-v4l2_m2m
+              --enable-vaapi
+              --enable-vdpau
+          - os_type: linux
+            os: ubuntu-22.04
+            arch: aarch64
+            shell: bash
+            cmake_generator: Unix Makefiles
+            host: aarch64-linux-gnu
+            ffmpeg_extras: >-
+              --enable-amf
+              --enable-cuda
+              --enable-cuda_llvm
+              --enable-encoder=h264_amf,hevc_amf
+              --enable-encoder=h264_nvenc,hevc_nvenc
+              --enable-encoder=h264_vaapi,hevc_vaapi
+              --enable-ffnvcodec
+              --enable-nvenc
+              --enable-v4l2_m2m
+              --enable-vaapi
+              --enable-vdpau
+          - os_type: macos
+            os: macos-11
+            arch: x86_64
+            shell: bash
+            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
+            ffmpeg_extras: >-
+              --enable-encoder=h264_videotoolbox,hevc_videotoolbox
+              --enable-videotoolbox
           - os_type: macos
             os: macos-12
             arch: aarch64
             shell: bash
-            cmake_generator: Xcode  # should be `Xcode` but that fails
+            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
             host: aarch64-apple-darwin
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
               --enable-videotoolbox
-          # - os_type: windows
-          #   os: windows-2022
-          #   arch: x86_64
-          #   shell: msys2 {0}
-          #   cmake_generator: MSYS Makefiles
-          #   ffmpeg_extras: >-
-          #     --enable-amf
-          #     --enable-cuda
-          #     --enable-d3d11va
-          #     --enable-encoder=h264_amf,hevc_amf
-          #     --enable-encoder=h264_mf,hevc_mf
-          #     --enable-encoder=h264_nvenc,hevc_nvenc
-          #     --enable-encoder=libx265
-          #     --enable-ffnvcodec
-          #     --enable-libx265
-          #     --enable-nvenc
-          #     --enable-mediafoundation
+          - os_type: windows
+            os: windows-2022
+            arch: x86_64
+            shell: msys2 {0}
+            cmake_generator: MSYS Makefiles
+            ffmpeg_extras: >-
+              --enable-amf
+              --enable-cuda
+              --enable-d3d11va
+              --enable-encoder=h264_amf,hevc_amf
+              --enable-encoder=h264_mf,hevc_mf
+              --enable-encoder=h264_nvenc,hevc_nvenc
+              --enable-ffnvcodec
+              --enable-nvenc
+              --enable-mediafoundation
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -332,8 +324,14 @@ jobs:
           CPU="apple-m1"
           TARGET="${{ matrix.host }}"
           ARCH="${{ matrix.arch }}"
+          CLFAGS="--target=${{ matrix.host }}"
+          CXXFLAGS="--target=${{ matrix.host }}"
+          LDFLAGS="--target=${{ matrix.host }}"
+          CMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
+          CMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
+          -DCMAKE_SYSTEM_PROCESSOR="$CPU"
           VAREOF
           )
           fi
@@ -351,7 +349,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::make"
-          PATH="$root_path/bin:$PATH" make -j$(nproc || sysctl -n hw.logicalcpu)
+          PATH="$root_path/bin:$PATH" make -j $(sysctl -n hw.logicalcpu)
           echo "::endgroup::"
 
           echo "::group::make install"
@@ -402,7 +400,7 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
           CPU="apple-m1"
-          MORE_C_FLAGS="--target=${{ matrix.host }} -march=$CPU"
+          MORE_C_FLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cpu=$CPU
@@ -434,6 +432,7 @@ jobs:
             --enable-encoder=libx264,libx265 \
             --enable-gpl \
             --enable-libx264 \
+            --enable-libx265
             --enable-static \
             --enable-swscale \
             --pkg-config=pkg-config \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -277,8 +277,8 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CC="clang"
-          CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          EXPORT CC="clang"
+          EXPORT CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -319,8 +319,8 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          CXXFLAGS="-std=c++11 ${CFLAGS}"
+          EXPORT CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          EXPORT CXXFLAGS="-std=c++11 ${CFLAGS}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DENABLE_ASSEMBLY=0
@@ -396,9 +396,9 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          CXXFLAGS="-std=c++11 ${CFLAGS}"
-          LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
+          EXPORT CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          EXPORT CXXFLAGS="-std=c++11 ${CFLAGS}"
+          EXPORT LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -241,11 +241,15 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-idr-on-amf.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
 
-      - name: Setup linux cross compilation
+      - name: Setup cross compilation
         id: cross
-        if: ${{ matrix.os_type == 'linux' && matrix.arch == 'aarch64' }}
+        if: ${{ matrix.arch == 'aarch64' }}
         run: |
+          if [[ matrix.os_type == 'linux' ]]; then
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
+          else
+          echo "CFLAGS=-arch arm64 -target arm64-apple-macosx -march=armv8" >> $GITHUB_OUTPUT
+          fi
 
       - name: amf
         if: ${{ matrix.os_type != 'macos' }}
@@ -273,11 +277,8 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
-          chmod +x ./gas-preprocessor.pl
-          export AS="./gas-preprocessor.pl -arch aarch64 -- clang -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CC="clang"
-          export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          export CFLAGS=${{ steps.cross.outputs.CFLAGS }}
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -318,13 +319,8 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
-          chmod +x ./gas-preprocessor.pl
-          export AS="./gas-preprocessor.pl"
-          export AS_ARGUMENTS="-arch aarch64"
-          export ASM_FLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          export CFLAGS=${{ steps.cross.outputs.CFLAGS }}
+          export CXXFLAGS="-std=c++11 ${CFLAGS}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DENABLE_ASSEMBLY=0
@@ -382,9 +378,9 @@ jobs:
         env:
           nvenc_path: ${{ steps.nvenc.outputs.nvenc_path }}
           root_path: ${{ steps.root.outputs.root_path }}
+          CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
         working-directory: ffmpeg_sources/ffmpeg
         run: |
-          set -x
           echo "::group::configure options"
           ./configure --help || true  # this command has a non zero exit status, but we should continue anyway
           echo "::endgroup::"
@@ -392,7 +388,6 @@ jobs:
           echo "::group::configure extra flags for cross compilation"
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CCPREFIX=${{ steps.cross.outputs.CCPREFIX }}
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cross-prefix=${CCPREFIX}
@@ -401,20 +396,16 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
-          chmod +x ./gas-preprocessor.pl
-          sudo mv ./gas-preprocessor.pl /usr/local/bin
-          export AS="gas-preprocessor.pl -arch aarch64 -- clang -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
+          export CFLAGS=${{ steps.cross.outputs.CFLAGS }}
+          export CXXFLAGS="-std=c++11 ${CFLAGS}"
+          export LDFLAGS="${CFLAGS} -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=aarch64
-          --cpu=armv8
           --cc=clang
           --cxx=clang++
           --target-os=darwin
           --enable-cross-compile
+          --disable-neon
           VAREOF
           )
           fi
@@ -465,7 +456,6 @@ jobs:
           echo "::group::make install"
           make install
           echo "::endgroup::"
-          set +x
 
           echo "::group::copy license"
           cp ./COPYING.GPLv2 $root_path/ffmpeg_build/LICENSE

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -273,8 +273,11 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CC="clang"
-          CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
+          chmod +x ./gas-preprocessor.pl
+          export AS="./gas-preprocessor.pl -arch aarch64 -- clang -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          export CC="clang"
+          export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -409,11 +412,9 @@ jobs:
           --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
-          --ar=ar
           --target-os=darwin
           --enable-cross-compile
           --enable-pic
-          --disable-neon
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -281,8 +281,7 @@ jobs:
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-darwin
-            VAREOF
-            )
+            VAREOF)
           fi
           echo "$extra_configure"
           echo "::endgroup::"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -270,7 +270,7 @@ jobs:
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             CC="clang -arch arm64"
-            extra_configure="--arch=arm64"
+            extra_configure="--host=arm64-darwin"
           fi
           echo "$extra_configure"
           echo "::endgroup::"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -413,6 +413,7 @@ jobs:
           --target-os=darwin
           --enable-cross-compile
           --enable-pic
+          --disable-neon
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -321,10 +321,10 @@ jobs:
           -DCROSS_COMPILE_ARM64=ON
           -DCMAKE_SYSTEM_PROCESSOR=aarch64
           -DCMAKE_C_COMPILER=clang
-          -DCMAKE_C_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          -DCMAKE_C_FLAGS="--target=${{ matrix.host }}"
           -DCMAKE_CXX_COMPILER=clang
-          -DCMAKE_CXX_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
-          -DCMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          -DCMAKE_CXX_FLAGS="--target=${{ matrix.host }}"
+          -DCMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }}"
           -DCMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
           VAREOF
           )

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -186,7 +186,7 @@ jobs:
                 gcc-${{ matrix.host }}
               echo "::endgroup::"
             fi
-        elif [[ ${{ matrix.os_type }} == "macos" ]]; then
+          elif [[ ${{ matrix.os_type }} == "macos" ]]; then
             brew install \
               automake \
               fdk-aac \
@@ -205,7 +205,7 @@ jobs:
               wget \
               yasm \
               xvid
-        fi
+          fi
 
       - name: Setup Dependencies Windows
         if: ${{ matrix.os_type == 'windows' }}

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -245,10 +245,10 @@ jobs:
         id: cross
         if: ${{ matrix.arch == 'aarch64' }}
         run: |
-          if [[ matrix.os_type == 'linux' ]]; then
+          if [[ ${{ matrix.os_type }} == 'linux' ]]; then
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
           else
-          echo "CFLAGS=-arch arm64 -target arm64-apple-macosx -march=armv8" >> $GITHUB_OUTPUT
+          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8" >> $GITHUB_OUTPUT
           fi
 
       - name: amf
@@ -327,9 +327,9 @@ jobs:
           -DCMAKE_SYSTEM_PROCESSOR=arm64
           -DCMAKE_OSX_ARCHITECTURES=arm64
           -DCMAKE_C_COMPILER=clang
-          -DCMAKE_C_COMPILER_TARGET=arm64-apple-macosx
+          -DCMAKE_C_COMPILER_TARGET=${{ matrix.host }}
           -DCMAKE_CXX_COMPILER=clang++
-          -DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macosx
+          -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.host }}
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -409,8 +409,8 @@ jobs:
           --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
-          --as=$AS
           --ar=ar
+          --cross-prefix=arm64-apple-darwin-
           --target-os=darwin
           --enable-cross-compile
           --enable-pic

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -188,7 +188,7 @@ jobs:
             fi
         elif [[ ${{ matrix.os_type }} == "macos" ]]; then
             brew install \
-              cmake \
+              automake \
               fdk-aac \
               git \
               lame \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -66,7 +66,7 @@ jobs:
             os: macos-12
             arch: aarch64
             shell: bash
-            cmake_generator: Xcode
+            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
             host: aarch64-apple-darwin
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
@@ -319,6 +319,7 @@ jobs:
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
+          -DCMAKE_SYSTEM_PROCESSOR=arm64
           -DCMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
           -DCMAKE_C_COMPILER=clang
           -DCMAKE_C_COMPILER_TARGET="${{ matrix.host }}"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -274,7 +274,6 @@ jobs:
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
-          # CFLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
           CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
@@ -394,7 +393,7 @@ jobs:
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang
-          --cxx=clang
+          --cxx=clang++
           --extra-cxxflags="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           --enable-cross-compile
           --enable-pic

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -403,12 +403,13 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
           chmod +x ./gas-preprocessor.pl
-          export AS="./gas-preprocessor.pl -arch aarch64 -- clang -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          sudo mv ./gas-preprocessor.pl /usr/local/bin
+          export AS="gas-preprocessor.pl -arch aarch64 -- clang -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
           extra_configure=$(cat <<VAREOF
-          --arch=${{ matrix.arch }}
+          --arch=aarch64
           --cpu=armv8
           --cc=clang
           --cxx=clang++

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -248,7 +248,7 @@ jobs:
           if [[ ${{ matrix.os_type }} == 'linux' ]]; then
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
           else
-          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8" >> $GITHUB_OUTPUT
+          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8 -mcpu=generic" >> $GITHUB_OUTPUT
           fi
 
       - name: amf
@@ -396,11 +396,12 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          CCPREFIX=""
           CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           CXXFLAGS="-std=c++11 ${CFLAGS}"
           LDFLAGS="${CFLAGS} -lc++"
           extra_configure=$(cat <<VAREOF
-          --arch=aarch64
+          --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
           --target-os=darwin

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -324,14 +324,13 @@ jobs:
           CPU="apple-m1"
           TARGET="${{ matrix.host }}"
           ARCH="${{ matrix.arch }}"
-          CFLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
-          CXXFLAGS="--target=${{ matrix.host }}  -march=${{ matrix.arch }}"
-          LDFLAGS="--target=${{ matrix.host }}  -march=${{ matrix.arch }}"
+          CFLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          CXXFLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          LDFLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
           CMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
-          CMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
-          -DCMAKE_SYSTEM_PROCESSOR="$CPU"
+          -DCMAKE_SYSTEM_PROCESSOR=arm64
           VAREOF
           )
           fi
@@ -400,7 +399,7 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
           CPU="apple-m1"
-          MORE_C_FLAGS="--target=${{ matrix.host }} -march=${{ matrix.arch }}"
+          MORE_C_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cpu=$CPU
@@ -428,10 +427,9 @@ jobs:
             --disable-autodetect \
             --disable-iconv \
             --enable-avcodec \
-            --enable-encoder=libx264,libx265 \
+            --enable-encoder=libx264 \
             --enable-gpl \
             --enable-libx264 \
-            --enable-libx265 \
             --enable-static \
             --enable-swscale \
             --pkg-config=pkg-config \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -315,15 +315,18 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DENABLE_ASSEMBLY=0
           -DCMAKE_SYSTEM_PROCESSOR=arm64
           -DCMAKE_OSX_ARCHITECTURES=arm64
           -DCMAKE_C_COMPILER=clang
-          -DCMAKE_C_COMPILER_TARGET="${{ matrix.host }}"
+          -DCMAKE_C_COMPILER_TARGET=arm64-apple-macosx
           -DCMAKE_CXX_COMPILER=clang++
-          -DCMAKE_CXX_COMPILER_TARGET="${{ matrix.host }}"
+          -DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macosx
+          -DENABLE_PIC=1
           VAREOF
           )
           fi
@@ -393,11 +396,13 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
-          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx"
+          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
+          --cross-prefix=arm64-apple-darwin-
+          --target-os=darwin
           --enable-cross-compile
           --enable-pic
           VAREOF

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -318,6 +318,7 @@ jobs:
           CPU="apple-m1"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
+          -DENABLE_ASSEMBLY=0
           -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
           -DCMAKE_SYSTEM_PROCESSOR=arm64
           -DCMAKE_OSX_ARCHITECTURES=arm64

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -132,7 +132,7 @@ jobs:
             deb [arch=$package_arch] $mirror $dist-security main restricted
             deb [arch=$package_arch] $mirror $dist-security universe
             deb [arch=$package_arch] $mirror $dist-security multiverse
-            VAREOF)
+          VAREOF)
           echo "::endgroup::"
 
           if [[ ${{ matrix.os_type }} == "linux" ]]; then

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -322,7 +322,7 @@ jobs:
           -DCMAKE_OSX_ARCHITECTURES=arm64
           -DCMAKE_C_COMPILER=clang
           -DCMAKE_C_COMPILER_TARGET="${{ matrix.host }}"
-          -DCMAKE_CXX_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
           -DCMAKE_CXX_COMPILER_TARGET="${{ matrix.host }}"
           VAREOF
           )
@@ -374,6 +374,7 @@ jobs:
           root_path: ${{ steps.root.outputs.root_path }}
         working-directory: ffmpeg_sources/ffmpeg
         run: |
+          set -x
           echo "::group::configure options"
           ./configure --help || true  # this command has a non zero exit status, but we should continue anyway
           echo "::endgroup::"
@@ -393,8 +394,10 @@ jobs:
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang
+          --extra-cflags="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           --cxx=clang++
           --extra-cxxflags="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
+          --extra-ldflags="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx"
           --enable-cross-compile
           --enable-pic
           VAREOF
@@ -411,8 +414,8 @@ jobs:
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
             --pkg-config-flags="--static" \
-            --extra-cflags="-I$root_path/ffmpeg_build/include -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic" \
-            --extra-ldflags="-L$root_path/ffmpeg_build/lib -arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx" \
+            --extra-cflags="-I$root_path/ffmpeg_build/include" \
+            --extra-ldflags="-L$root_path/ffmpeg_build/lib" \
             --extra-libs="-lpthread -lm" \
             --bindir="$root_path/bin" \
             --disable-all \
@@ -447,6 +450,7 @@ jobs:
           echo "::group::make install"
           make install
           echo "::endgroup::"
+          set +x
 
           echo "::group::copy license"
           cp ./COPYING.GPLv2 $root_path/ffmpeg_build/LICENSE

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -248,7 +248,8 @@ jobs:
           if [[ ${{ matrix.os_type }} == 'linux' ]]; then
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
           else
-          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8" >> $GITHUB_OUTPUT
+          CFLAGS="-arch arm64 -target ${{ matrix.host }} -march=armv8"
+          echo "CFLAGS=${CFLAGS}" >> $GITHUB_OUTPUT
           fi
 
       - name: amf

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -398,7 +398,7 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           CXXFLAGS="-std=c++11 ${CFLAGS}"
-          LDFLAGS="${CFLAGS} -lc++"
+          LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -315,6 +315,11 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
+          chmod +x ./gas-preprocessor.pl
+          export AS="./gas-preprocessor.pl"
+          export AS_ARGUMENTS="-arch aarch64"
+          export ASM_FLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           extra_configure=$(cat <<VAREOF
@@ -394,6 +399,9 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          curl -LO https://github.com/arthenica/gas-preprocessor/raw/v20210917/gas-preprocessor.pl
+          chmod +x ./gas-preprocessor.pl
+          export AS="./gas-preprocessor.pl -arch aarch64 -- clang -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CFLAGS="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export CXXFLAGS="-std=c++11 -arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -121,18 +121,18 @@ jobs:
           fi
 
           mirror="http://ports.ubuntu.com/ubuntu-ports"
-          extra_sources=$(cat <<VAREOF
-          deb [arch=$package_arch] $mirror $dist main restricted
-          deb [arch=$package_arch] $mirror $dist-updates main restricted
-          deb [arch=$package_arch] $mirror $dist universe
-          deb [arch=$package_arch] $mirror $dist-updates universe
-          deb [arch=$package_arch] $mirror $dist multiverse
-          deb [arch=$package_arch] $mirror $dist-updates multiverse
-          deb [arch=$package_arch] $mirror $dist-backports main restricted universe multiverse
-          deb [arch=$package_arch] $mirror $dist-security main restricted
-          deb [arch=$package_arch] $mirror $dist-security universe
-          deb [arch=$package_arch] $mirror $dist-security multiverse
-          VAREOF
+          extra_sources=$(cat <<-VAREOF
+            deb [arch=$package_arch] $mirror $dist main restricted
+            deb [arch=$package_arch] $mirror $dist-updates main restricted
+            deb [arch=$package_arch] $mirror $dist universe
+            deb [arch=$package_arch] $mirror $dist-updates universe
+            deb [arch=$package_arch] $mirror $dist multiverse
+            deb [arch=$package_arch] $mirror $dist-updates multiverse
+            deb [arch=$package_arch] $mirror $dist-backports main restricted universe multiverse
+            deb [arch=$package_arch] $mirror $dist-security main restricted
+            deb [arch=$package_arch] $mirror $dist-security universe
+            deb [arch=$package_arch] $mirror $dist-security multiverse
+            VAREOF
           )
           echo "::endgroup::"
 
@@ -246,9 +246,9 @@ jobs:
         if: ${{ matrix.arch == 'aarch64' }}
         run: |
           if [[ ${{ matrix.os_type }} == 'linux' ]]; then
-          echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
+            echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
           else
-          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8-a -mcpu=generic" >> $GITHUB_OUTPUT
+            echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8-a -mcpu=generic" >> $GITHUB_OUTPUT
           fi
 
       - name: amf
@@ -271,18 +271,18 @@ jobs:
           echo "::group::configure extra flags for cross compilation"
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
-          extra_configure=$(cat <<VAREOF
-          --host=${{ matrix.arch }}-${{ matrix.os_type }}
-          --cross-prefix=${CCPREFIX}
-          VAREOF
-          )
+            extra_configure=$(cat <<-VAREOF
+              --host=${{ matrix.arch }}-${{ matrix.os_type }}
+              --cross-prefix=${CCPREFIX}
+              VAREOF
+            )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          export CC="clang"
-          export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          extra_configure=$(cat <<VAREOF
-          --host=${{ matrix.arch }}-darwin
-          VAREOF
-          )
+            export CC="clang"
+            export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+            extra_configure=$(cat <<-VAREOF
+              --host=${{ matrix.arch }}-darwin
+              VAREOF
+            )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -317,21 +317,21 @@ jobs:
           # not currently supported in `aarch64`
           extra_configure="-DENABLE_HDR10_PLUS=1"
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
-          extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
+            extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          export CXXFLAGS="-std=c++11 ${CFLAGS}"
-          extra_configure=$(cat <<VAREOF
-          -DCROSS_COMPILE_ARM64=ON
-          -DENABLE_ASSEMBLY=0
-          -DCMAKE_SYSTEM_PROCESSOR=arm64
-          -DCMAKE_OSX_ARCHITECTURES=arm64
-          -DCMAKE_C_COMPILER=clang
-          -DCMAKE_C_COMPILER_TARGET=${{ matrix.host }}
-          -DCMAKE_CXX_COMPILER=clang++
-          -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.host }}
-          VAREOF
-          )
+            export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+            export CXXFLAGS="-std=c++11 ${CFLAGS}"
+            extra_configure=$(cat <<-VAREOF
+              -DCROSS_COMPILE_ARM64=ON
+              -DENABLE_ASSEMBLY=0
+              -DCMAKE_SYSTEM_PROCESSOR=arm64
+              -DCMAKE_OSX_ARCHITECTURES=arm64
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_C_COMPILER_TARGET=${{ matrix.host }}
+              -DCMAKE_CXX_COMPILER=clang++
+              -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.host }}
+              VAREOF
+            )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -387,27 +387,27 @@ jobs:
           echo "::group::configure extra flags for cross compilation"
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CCPREFIX=${{ steps.cross.outputs.CCPREFIX }}
-          extra_configure=$(cat <<VAREOF
-          --arch=${{ matrix.arch }}
-          --cross-prefix=${CCPREFIX}
-          --enable-cross-compile
-          --target-os=${{ matrix.os_type }}
-          VAREOF
-          )
+            CCPREFIX=${{ steps.cross.outputs.CCPREFIX }}
+            extra_configure=$(cat <<-VAREOF
+              --arch=${{ matrix.arch }}
+              --cross-prefix=${CCPREFIX}
+              --enable-cross-compile
+              --target-os=${{ matrix.os_type }}
+              VAREOF
+            )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          export CXXFLAGS="-std=c++11 ${CFLAGS}"
-          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target ${{ matrix.host }} -lc++"
-          extra_configure=$(cat <<VAREOF
-          --arch=${{ matrix.arch }}
-          --cc=clang
-          --cxx=clang++
-          --target-os=darwin
-          --enable-cross-compile
-          --disable-neon
-          VAREOF
-          )
+            export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+            export CXXFLAGS="-std=c++11 ${CFLAGS}"
+            export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target ${{ matrix.host }} -lc++"
+            extra_configure=$(cat <<-VAREOF
+              --arch=${{ matrix.arch }}
+              --cc=clang
+              --cxx=clang++
+              --target-os=darwin
+              --enable-cross-compile
+              --disable-neon
+              VAREOF
+            )
           fi
           echo "$extra_configure"
           echo "::endgroup::"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -394,7 +394,7 @@ jobs:
           MORE_LD_FLAGS="-arch=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
-          --cc="clang"
+          --cc=clang
           --enable-cross-compile
           --enable-pic
           VAREOF

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -396,8 +396,8 @@ jobs:
           export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
-          --cc="clang"
-          --cxx="clang++"
+          --cc=clang
+          --cxx=clang++
           --enable-cross-compile
           --enable-pic
           VAREOF

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -121,7 +121,7 @@ jobs:
           fi
 
           mirror="http://ports.ubuntu.com/ubuntu-ports"
-          extra_sources=$(cat <<-VAREOF
+          extra_sources=$(cat <<- VAREOF
             deb [arch=$package_arch] $mirror $dist main restricted
             deb [arch=$package_arch] $mirror $dist-updates main restricted
             deb [arch=$package_arch] $mirror $dist universe
@@ -271,7 +271,7 @@ jobs:
           echo "::group::configure extra flags for cross compilation"
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
-            extra_configure=$(cat <<-VAREOF
+            extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-${{ matrix.os_type }}
               --cross-prefix=${CCPREFIX}
               VAREOF
@@ -279,7 +279,7 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CC="clang"
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-            extra_configure=$(cat <<-VAREOF
+            extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-darwin
               VAREOF
             )
@@ -321,7 +321,7 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             export CXXFLAGS="-std=c++11 ${CFLAGS}"
-            extra_configure=$(cat <<-VAREOF
+            extra_configure=$(cat <<- VAREOF
               -DCROSS_COMPILE_ARM64=ON
               -DENABLE_ASSEMBLY=0
               -DCMAKE_SYSTEM_PROCESSOR=arm64
@@ -388,7 +388,7 @@ jobs:
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
             CCPREFIX=${{ steps.cross.outputs.CCPREFIX }}
-            extra_configure=$(cat <<-VAREOF
+            extra_configure=$(cat <<- VAREOF
               --arch=${{ matrix.arch }}
               --cross-prefix=${CCPREFIX}
               --enable-cross-compile
@@ -399,7 +399,7 @@ jobs:
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             export CXXFLAGS="-std=c++11 ${CFLAGS}"
             export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target ${{ matrix.host }} -lc++"
-            extra_configure=$(cat <<-VAREOF
+            extra_configure=$(cat <<- VAREOF
               --arch=${{ matrix.arch }}
               --cc=clang
               --cxx=clang++

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -103,8 +103,8 @@ jobs:
           persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
           fetch-depth: 0  # otherwise, will fail to push refs to dest repo
 
-      - name: Setup Dependencies Linux
-        if: ${{ matrix.os_type == 'linux' }}
+      - name: Setup Dependencies Unix
+        if: ${{ matrix.os_type != 'windows' }}
         run: |
           echo "::group::${{ matrix.os_type }} dependencies"
           if [[ ${{ matrix.os }} == "ubuntu-18.04" ]]; then
@@ -135,62 +135,59 @@ jobs:
           VAREOF
           )
 
-          if [[ $package_arch != "amd64" ]]; then
-            # fix original sources
-            sudo sed -i -e "s#deb http#deb [arch=amd64] http#g" /etc/apt/sources.list
 
-            sudo dpkg --add-architecture $package_arch
+          if [[ ${{ matrix.os_type }} == "linux" ]]; then
+            if [[ $package_arch != "amd64" ]]; then
+              # fix original sources
+              sudo sed -i -e "s#deb http#deb [arch=amd64] http#g" /etc/apt/sources.list
 
-            echo "$extra_sources" | sudo tee -a /etc/apt/sources.list
-            echo "----"
-            sudo cat /etc/apt/sources.list
-          fi
+              sudo dpkg --add-architecture $package_arch
 
-          sudo apt-get update -qq && sudo apt-get -y install \
-            autoconf \
-            automake \
-            build-essential \
-            cmake \
-            git-core \
-            libass-dev \
-            libfreetype6-dev \
-            libgnutls28-dev \
-            libmp3lame-dev \
-            libnuma-dev \
-            libopus-dev \
-            libsdl2-dev \
-            libtool \
-            libva-dev:$package_arch \
-            libvdpau-dev \
-            libvorbis-dev \
-            libxcb1-dev \
-            libxcb-shm0-dev \
-            libxcb-xfixes0-dev \
-            meson \
-            nasm \
-            ninja-build \
-            pkg-config \
-            texinfo \
-            wget \
-            yasm \
-            zlib1g-dev
-          echo "::endgroup::"
+              echo "$extra_sources" | sudo tee -a /etc/apt/sources.list
+              echo "----"
+              sudo cat /etc/apt/sources.list
+            fi
 
-          if [[ ${{ matrix.arch }} == "aarch64" ]]; then
-            echo "::group::${{ matrix.os_type }}-${{ matrix.arch }} dependencies"
-            sudo apt-get -y install \
-              binutils-${{ matrix.host }} \
-              g++-${{ matrix.host }} \
-              gcc-${{ matrix.host }}
-            echo "::endgroup::"
-          fi
-
-      - name: Setup Dependencies macOS
-        if: ${{ matrix.os_type == 'macos' }}
-        run: |
-            brew install \
+            sudo apt-get update -qq && sudo apt-get -y install \
               autoconf \
               automake \
+              build-essential \
+              cmake \
+              git-core \
+              libass-dev \
+              libfreetype6-dev \
+              libgnutls28-dev \
+              libmp3lame-dev \
+              libnuma-dev \
+              libopus-dev \
+              libsdl2-dev \
+              libtool \
+              libva-dev:$package_arch \
+              libvdpau-dev \
+              libvorbis-dev \
+              libxcb1-dev \
+              libxcb-shm0-dev \
+              libxcb-xfixes0-dev \
+              meson \
+              nasm \
+              ninja-build \
+              pkg-config \
+              texinfo \
+              wget \
+              yasm \
+              zlib1g-dev
+            echo "::endgroup::"
+
+            if [[ ${{ matrix.arch }} == "aarch64" ]]; then
+              echo "::group::${{ matrix.os_type }}-${{ matrix.arch }} dependencies"
+              sudo apt-get -y install \
+                binutils-${{ matrix.host }} \
+                g++-${{ matrix.host }} \
+                gcc-${{ matrix.host }}
+              echo "::endgroup::"
+            fi
+        elif [[ ${{ matrix.os_type }} == "macos" ]]; then
+            brew install \
               cmake \
               fdk-aac \
               git \
@@ -201,7 +198,6 @@ jobs:
               libvpx \
               nasm \
               opus \
-              pkg-config \
               sdl \
               shtool \
               texi2html \
@@ -209,6 +205,7 @@ jobs:
               wget \
               yasm \
               xvid
+        fi
 
       - name: Setup Dependencies Windows
         if: ${{ matrix.os_type == 'windows' }}

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -334,7 +334,6 @@ jobs:
           -DCMAKE_C_COMPILER_TARGET=arm64-apple-macosx
           -DCMAKE_CXX_COMPILER=clang++
           -DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macosx
-          -DENABLE_PIC=1
           VAREOF
           )
           fi
@@ -410,11 +409,11 @@ jobs:
           export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
+          --cpu=armv8
           --cc=clang
           --cxx=clang++
           --target-os=darwin
           --enable-cross-compile
-          --enable-pic
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -132,8 +132,7 @@ jobs:
             deb [arch=$package_arch] $mirror $dist-security main restricted
             deb [arch=$package_arch] $mirror $dist-security universe
             deb [arch=$package_arch] $mirror $dist-security multiverse
-          VAREOF
-          )
+            VAREOF)
           echo "::endgroup::"
 
           if [[ ${{ matrix.os_type }} == "linux" ]]; then
@@ -274,8 +273,7 @@ jobs:
             extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-${{ matrix.os_type }}
               --cross-prefix=${CCPREFIX}
-            VAREOF
-            )
+            VAREOF)
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CC="clang"
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
@@ -329,8 +327,7 @@ jobs:
               -DCMAKE_C_COMPILER_TARGET=${{ matrix.host }}
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.host }}
-            VAREOF
-            )
+            VAREOF)
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -392,8 +389,7 @@ jobs:
               --cross-prefix=${CCPREFIX}
               --enable-cross-compile
               --target-os=${{ matrix.os_type }}
-            VAREOF
-            )
+            VAREOF)
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             export CXXFLAGS="-std=c++11 ${CFLAGS}"
@@ -405,8 +401,7 @@ jobs:
               --target-os=darwin
               --enable-cross-compile
               --disable-neon
-            VAREOF
-            )
+            VAREOF)
           fi
           echo "$extra_configure"
           echo "::endgroup::"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -66,7 +66,7 @@ jobs:
             os: macos-12
             arch: aarch64
             shell: bash
-            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
+            cmake_generator: Xcode
             host: aarch64-apple-darwin
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
@@ -312,21 +312,20 @@ jobs:
 
           # not currently supported in `aarch64`
           extra_configure="-DENABLE_HDR10_PLUS=1"
+          
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CC="clang"
-          CXX="clang"
           CPU="apple-m1"
-          TARGET="${{ matrix.host }}"
-          ARCH="${{ matrix.arch }}"
-          CFLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
-          CXXFLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
-          LDFLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
-          CMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DCMAKE_SYSTEM_PROCESSOR=aarch64
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          -DCMAKE_CXX_COMPILER=clang
+          -DCMAKE_CXX_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          -DCMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          -DCMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -132,7 +132,7 @@ jobs:
             deb [arch=$package_arch] $mirror $dist-security main restricted
             deb [arch=$package_arch] $mirror $dist-security universe
             deb [arch=$package_arch] $mirror $dist-security multiverse
-            VAREOF
+          VAREOF
           )
           echo "::endgroup::"
 
@@ -274,14 +274,14 @@ jobs:
             extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-${{ matrix.os_type }}
               --cross-prefix=${CCPREFIX}
-              VAREOF
+            VAREOF
             )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CC="clang"
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-darwin
-              VAREOF
+            VAREOF
             )
           fi
           echo "$extra_configure"
@@ -330,7 +330,7 @@ jobs:
               -DCMAKE_C_COMPILER_TARGET=${{ matrix.host }}
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.host }}
-              VAREOF
+            VAREOF
             )
           fi
           echo "$extra_configure"
@@ -393,7 +393,7 @@ jobs:
               --cross-prefix=${CCPREFIX}
               --enable-cross-compile
               --target-os=${{ matrix.os_type }}
-              VAREOF
+            VAREOF
             )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
@@ -406,7 +406,7 @@ jobs:
               --target-os=darwin
               --enable-cross-compile
               --disable-neon
-              VAREOF
+            VAREOF
             )
           fi
           echo "$extra_configure"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -312,20 +312,18 @@ jobs:
 
           # not currently supported in `aarch64`
           extra_configure="-DENABLE_HDR10_PLUS=1"
-          
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CPU="apple-m1"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
-          -DCMAKE_SYSTEM_PROCESSOR=aarch64
-          -DCMAKE_C_COMPILER=clang
-          -DCMAKE_C_FLAGS="--target=${{ matrix.host }}"
-          -DCMAKE_CXX_COMPILER=clang
-          -DCMAKE_CXX_FLAGS="--target=${{ matrix.host }}"
-          -DCMAKE_EXE_LINKER_FLAGS="--target=${{ matrix.host }}"
+          -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
           -DCMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_C_COMPILER_TARGET="${{ matrix.host }}"
+          -DCMAKE_CXX_COMPILER=clang
+          -DCMAKE_CXX_COMPILER_TARGET="${{ matrix.host }}"
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -329,7 +329,7 @@ jobs:
           CMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
-          -DCMAKE_SYSTEM_PROCESSOR=arm64
+          -DCMAKE_SYSTEM_PROCESSOR=aarch64
           VAREOF
           )
           fi

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -410,7 +410,6 @@ jobs:
           --cc=clang
           --cxx=clang++
           --ar=ar
-          --cross-prefix=arm64-apple-darwin-
           --target-os=darwin
           --enable-cross-compile
           --enable-pic

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -277,8 +277,8 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          EXPORT CC="clang"
-          EXPORT CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          export CC="clang"
+          export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -319,8 +319,8 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          EXPORT CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          EXPORT CXXFLAGS="-std=c++11 ${CFLAGS}"
+          export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          export CXXFLAGS="-std=c++11 ${CFLAGS}"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DENABLE_ASSEMBLY=0
@@ -396,9 +396,9 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          EXPORT CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
-          EXPORT CXXFLAGS="-std=c++11 ${CFLAGS}"
-          EXPORT LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
+          export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
+          export CXXFLAGS="-std=c++11 ${CFLAGS}"
+          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -315,11 +315,9 @@ jobs:
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
           extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CPU="apple-m1"
           extra_configure=$(cat <<VAREOF
           -DCROSS_COMPILE_ARM64=ON
           -DENABLE_ASSEMBLY=0
-          -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
           -DCMAKE_SYSTEM_PROCESSOR=arm64
           -DCMAKE_OSX_ARCHITECTURES=arm64
           -DCMAKE_C_COMPILER=clang
@@ -392,14 +390,13 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CC="clang"
-          CPU="apple-m1"
-          MORE_C_FLAGS="--target=${{ matrix.host }} -mcpu=$CPU"
+          MORE_C_FLAGS="--target=${{ matrix.host }} -arch=${{ matrix.arch }}"
+          MORE_LD_FLAGS="-arch=${{ matrix.arch }}"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
-          --cpu=$CPU
+          --cc="clang"
           --enable-cross-compile
-          --target-os=darwin
+          --enable-pic
           VAREOF
           )
           fi
@@ -415,7 +412,7 @@ jobs:
             --prefix="$root_path/ffmpeg_build" \
             --pkg-config-flags="--static" \
             --extra-cflags="-I$root_path/ffmpeg_build/include ${MORE_C_FLAGS}" \
-            --extra-ldflags="-L$root_path/ffmpeg_build/lib ${MORE_C_FLAGS}" \
+            --extra-ldflags="-L$root_path/ffmpeg_build/lib ${MORE_LD_FLAGS}" \
             --extra-libs="-lpthread -lm" \
             --bindir="$root_path/bin" \
             --disable-all \

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -248,7 +248,7 @@ jobs:
           if [[ ${{ matrix.os_type }} == 'linux' ]]; then
           echo "CCPREFIX=/usr/bin/${{ matrix.host }}-" >> $GITHUB_OUTPUT
           else
-          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8 -mcpu=generic" >> $GITHUB_OUTPUT
+          echo "CFLAGS=-arch arm64 -target ${{ matrix.host }} -march=armv8-a -mcpu=generic" >> $GITHUB_OUTPUT
           fi
 
       - name: amf
@@ -378,7 +378,6 @@ jobs:
         env:
           nvenc_path: ${{ steps.nvenc.outputs.nvenc_path }}
           root_path: ${{ steps.root.outputs.root_path }}
-          CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
         working-directory: ffmpeg_sources/ffmpeg
         run: |
           echo "::group::configure options"
@@ -388,6 +387,7 @@ jobs:
           echo "::group::configure extra flags for cross compilation"
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
+          CCPREFIX=${{ steps.cross.outputs.CCPREFIX }}
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cross-prefix=${CCPREFIX}
@@ -396,7 +396,6 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CCPREFIX=""
           CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           CXXFLAGS="-std=c++11 ${CFLAGS}"
           LDFLAGS="${CFLAGS} -lc++"
@@ -404,6 +403,7 @@ jobs:
           --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
+          --ar=ar
           --target-os=darwin
           --enable-cross-compile
           --disable-neon

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -132,7 +132,8 @@ jobs:
             deb [arch=$package_arch] $mirror $dist-security main restricted
             deb [arch=$package_arch] $mirror $dist-security universe
             deb [arch=$package_arch] $mirror $dist-security multiverse
-          VAREOF)
+          VAREOF
+          )
           echo "::endgroup::"
 
           if [[ ${{ matrix.os_type }} == "linux" ]]; then
@@ -273,13 +274,15 @@ jobs:
             extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-${{ matrix.os_type }}
               --cross-prefix=${CCPREFIX}
-            VAREOF)
+          VAREOF
+          )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CC="clang"
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             extra_configure=$(cat <<- VAREOF
               --host=${{ matrix.arch }}-darwin
-            VAREOF)
+          VAREOF
+          )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -327,7 +330,8 @@ jobs:
               -DCMAKE_C_COMPILER_TARGET=${{ matrix.host }}
               -DCMAKE_CXX_COMPILER=clang++
               -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.host }}
-            VAREOF)
+          VAREOF
+          )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -389,7 +393,8 @@ jobs:
               --cross-prefix=${CCPREFIX}
               --enable-cross-compile
               --target-os=${{ matrix.os_type }}
-            VAREOF)
+          VAREOF
+          )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             export CXXFLAGS="-std=c++11 ${CFLAGS}"
@@ -401,7 +406,8 @@ jobs:
               --target-os=darwin
               --enable-cross-compile
               --disable-neon
-            VAREOF)
+          VAREOF
+          )
           fi
           echo "$extra_configure"
           echo "::endgroup::"

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -19,76 +19,81 @@ jobs:
       fail-fast: false  # false to test all, true to fail entire job if any fail
       matrix:
         include:
-          - os_type: linux
-            os: ubuntu-20.04  # Pinned until all platforms moved to 22.04
-            arch: x86_64
-            shell: bash
-            cmake_generator: Unix Makefiles
-            ffmpeg_extras: >-
-              --enable-amf
-              --enable-cuda
-              --enable-cuda_llvm
-              --enable-encoder=h264_amf,hevc_amf
-              --enable-encoder=h264_nvenc,hevc_nvenc
-              --enable-encoder=h264_vaapi,hevc_vaapi
-              --enable-ffnvcodec
-              --enable-libx265
-              --enable-nvenc
-              --enable-v4l2_m2m
-              --enable-vaapi
-              --enable-vdpau
-          - os_type: linux
-            os: ubuntu-22.04
-            arch: aarch64
-            shell: bash
-            cmake_generator: Unix Makefiles
-            host: aarch64-linux-gnu
-            ffmpeg_extras: >-
-              --enable-amf
-              --enable-cuda
-              --enable-cuda_llvm
-              --enable-encoder=h264_amf,hevc_amf
-              --enable-encoder=h264_nvenc,hevc_nvenc
-              --enable-encoder=h264_vaapi,hevc_vaapi
-              --enable-ffnvcodec
-              --enable-libx265
-              --enable-nvenc
-              --enable-v4l2_m2m
-              --enable-vaapi
-              --enable-vdpau
+          # - os_type: linux
+          #   os: ubuntu-20.04  # Pinned until all platforms moved to 22.04
+          #   arch: x86_64
+          #   shell: bash
+          #   cmake_generator: Unix Makefiles
+          #   ffmpeg_extras: >-
+          #     --enable-amf
+          #     --enable-cuda
+          #     --enable-cuda_llvm
+          #     --enable-encoder=h264_amf,hevc_amf
+          #     --enable-encoder=h264_nvenc,hevc_nvenc
+          #     --enable-encoder=h264_vaapi,hevc_vaapi
+          #     --enable-encoder=libx265
+          #     --enable-ffnvcodec
+          #     --enable-libx265
+          #     --enable-nvenc
+          #     --enable-v4l2_m2m
+          #     --enable-vaapi
+          #     --enable-vdpau
+          # - os_type: linux
+          #   os: ubuntu-22.04
+          #   arch: aarch64
+          #   shell: bash
+          #   cmake_generator: Unix Makefiles
+          #   host: aarch64-linux-gnu
+          #   ffmpeg_extras: >-
+          #     --enable-amf
+          #     --enable-cuda
+          #     --enable-cuda_llvm
+          #     --enable-encoder=h264_amf,hevc_amf
+          #     --enable-encoder=h264_nvenc,hevc_nvenc
+          #     --enable-encoder=h264_vaapi,hevc_vaapi
+          #     --enable-encoder=libx265
+          #     --enable-ffnvcodec
+          #     --enable-libx265
+          #     --enable-nvenc
+          #     --enable-v4l2_m2m
+          #     --enable-vaapi
+          #     --enable-vdpau
+          # - os_type: macos
+          #   os: macos-11
+          #   arch: x86_64
+          #   shell: bash
+          #   cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
+          #   ffmpeg_extras: >-
+          #     --enable-encoder=h264_videotoolbox,hevc_videotoolbox
+          #     --enable-encoder=libx265
+          #     --enable-videotoolbox
+          #     --enable-libx265
           - os_type: macos
             os: macos-11
-            arch: x86_64
+            arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
+            host: arm64-apple-darwin
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
               --enable-videotoolbox
-              --enable-libx265
-          - os_type: macos
-            os: macos-11
-            arch: aarch64
-            shell: bash
-            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
-            ffmpeg_extras: >-
-              --enable-encoder=h264_videotoolbox,hevc_videotoolbox
-              --enable-videotoolbox
-          - os_type: windows
-            os: windows-2022
-            arch: x86_64
-            shell: msys2 {0}
-            cmake_generator: MSYS Makefiles
-            ffmpeg_extras: >-
-              --enable-amf
-              --enable-cuda
-              --enable-d3d11va
-              --enable-encoder=h264_amf,hevc_amf
-              --enable-encoder=h264_mf,hevc_mf
-              --enable-encoder=h264_nvenc,hevc_nvenc
-              --enable-ffnvcodec
-              --enable-libx265
-              --enable-nvenc
-              --enable-mediafoundation
+          # - os_type: windows
+          #   os: windows-2022
+          #   arch: x86_64
+          #   shell: msys2 {0}
+          #   cmake_generator: MSYS Makefiles
+          #   ffmpeg_extras: >-
+          #     --enable-amf
+          #     --enable-cuda
+          #     --enable-d3d11va
+          #     --enable-encoder=h264_amf,hevc_amf
+          #     --enable-encoder=h264_mf,hevc_mf
+          #     --enable-encoder=h264_nvenc,hevc_nvenc
+          #     --enable-encoder=libx265
+          #     --enable-ffnvcodec
+          #     --enable-libx265
+          #     --enable-nvenc
+          #     --enable-mediafoundation
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -202,6 +207,12 @@ jobs:
               wget \
               yasm \
               xvid
+            
+            which llvm-gcc || true
+            which clang || true
+            which ar || true
+            which llvm-ar || true
+            which ld || true
 
       - name: Setup Dependencies Windows
         if: ${{ matrix.os_type == 'windows' }}
@@ -269,8 +280,12 @@ jobs:
           VAREOF
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-            CC="clang -arch arm64"
-            extra_configure="--host=arm64-darwin"
+          CC="clang"
+          CFLAGS="-target aarch64-apple-darwin"
+          extra_configure=$(cat <<VAREOF
+          --host=arm64-darwin
+          VAREOF
+          )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -278,6 +293,7 @@ jobs:
           echo "::group::configure"
           PATH="$root_path/bin:$PATH" \
             PKG_CONFIG_PATH="$root_path/ffmpeg_build/lib/pkgconfig" \
+            $test_env \
             ./configure \
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
@@ -295,7 +311,7 @@ jobs:
           echo "::endgroup::"
 
       - name: libx265
-        if: ${{ matrix.os_type != 'macos' && matrix.arch != 'aarch64' }}
+        if: ${{ matrix.os_type != 'macos' || matrix.arch != 'aarch64' }}
         env:
           root_path: ${{ steps.root.outputs.root_path }}
           CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
@@ -353,9 +369,9 @@ jobs:
         env:
           nvenc_path: ${{ steps.nvenc.outputs.nvenc_path }}
           root_path: ${{ steps.root.outputs.root_path }}
-          CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
         working-directory: ffmpeg_sources/ffmpeg
         run: |
+          set -o xtrace
           echo "::group::configure options"
           ./configure --help || true  # this command has a non zero exit status, but we should continue anyway
           echo "::endgroup::"
@@ -363,6 +379,7 @@ jobs:
           echo "::group::configure extra flags for cross compilation"
           extra_configure=""
           if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
+          CCPREFIX=${{ steps.cross.outputs.CCPREFIX }}
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cross-prefix=${CCPREFIX}
@@ -370,13 +387,18 @@ jobs:
           --target-os=${{ matrix.os_type }}
           VAREOF
           )
+          targetos=${{ matrix.host }}
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
-          CC='clang -arch arm64'
+          targetos=darwin
+          CC="clang"
+          CFLAGS="-target aarch64-apple-darwin"
           extra_configure=$(cat <<VAREOF
-          --arch=${{ matrix.arch }}
+          --arch=aarch64
           --enable-cross-compile
+          --target-os=darwin
           VAREOF
           )
+          # --cross-prefix="$root_path/ffmpeg_build"
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -384,7 +406,7 @@ jobs:
           echo "::group::configure"
           set +e  # do not fail
           PATH="$root_path/bin:$PATH" \
-            PKG_CONFIG_PATH="$nvenc_path:$root_path/ffmpeg_build/lib/pkgconfig:/usr/lib/${{ matrix.host }}/pkgconfig" \
+            PKG_CONFIG_PATH="$nvenc_path:$root_path/ffmpeg_build/lib/pkgconfig:/usr/lib/$targetos/pkgconfig" \
             ./configure \
             $extra_configure \
             --prefix="$root_path/ffmpeg_build" \
@@ -397,7 +419,7 @@ jobs:
             --disable-autodetect \
             --disable-iconv \
             --enable-avcodec \
-            --enable-encoder=libx264,libx265 \
+            --enable-encoder=libx264 \
             --enable-gpl \
             --enable-libx264 \
             --enable-static \
@@ -424,6 +446,7 @@ jobs:
           echo "::group::make install"
           make install
           echo "::endgroup::"
+          set +o xtrace
 
           echo "::group::copy license"
           cp ./COPYING.GPLv2 $root_path/ffmpeg_build/LICENSE

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -320,7 +320,7 @@ jobs:
           -DCROSS_COMPILE_ARM64=ON
           -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
           -DCMAKE_SYSTEM_PROCESSOR=arm64
-          -DCMAKE_OSX_ARCHITECTURES="${{ matrix.arch }}"
+          -DCMAKE_OSX_ARCHITECTURES=arm64
           -DCMAKE_C_COMPILER=clang
           -DCMAKE_C_COMPILER_TARGET="${{ matrix.host }}"
           -DCMAKE_CXX_COMPILER=clang

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -72,7 +72,7 @@ jobs:
             os: macos-12
             arch: aarch64
             shell: bash
-            cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
+            cmake_generator: Xcode  # should be `Xcode` but that fails
             host: aarch64-apple-darwin
             ffmpeg_extras: >-
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
@@ -285,7 +285,7 @@ jobs:
           )
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
-          CFLAGS="-target ${{ matrix.host }}"
+          CFLAGS="--target=${{ matrix.host }}"
           extra_configure=$(cat <<VAREOF
           --host=${{ matrix.arch }}-darwin
           VAREOF
@@ -314,18 +314,28 @@ jobs:
           echo "::endgroup::"
 
       - name: libx265
-        if: ${{ matrix.os_type != 'macos' || matrix.arch != 'aarch64' }}
+        # if: ${{ matrix.os_type != 'macos' || matrix.arch != 'aarch64' }}
         env:
           root_path: ${{ steps.root.outputs.root_path }}
           CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
         working-directory: ffmpeg_sources/x265_git
         run: |
           echo "::group::configure extra flags for cross compilation"
-          extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
 
-          if [[ ${{ matrix.arch }} != "aarch64" ]]; then
-            # not currently supported in `aarch64`
-            extra_configure="-DENABLE_HDR10_PLUS=1"
+          # not currently supported in `aarch64`
+          extra_configure="-DENABLE_HDR10_PLUS=1"
+          if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} == "aarch64" ]]; then
+          extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
+          elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
+          CC="clang"
+          CXX="clang"
+          CPU="apple-m1"
+          TARGET="${{ matrix.host }}"
+          ARCH="${{ matrix.arch }}"
+          extra_configure=$(cat <<VAREOF
+          -DCROSS_COMPILE_ARM64=ON
+          VAREOF
+          )
           fi
           echo "$extra_configure"
           echo "::endgroup::"
@@ -392,7 +402,7 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           CC="clang"
           CPU="apple-m1"
-          MORE_C_FLAGS="-target=${{ matrix.host }} -march=$CPU"
+          MORE_C_FLAGS="--target=${{ matrix.host }} -march=$CPU"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cpu=$CPU

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -394,6 +394,8 @@ jobs:
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang
+          --cxx=clang
+          --extra-cxxflags="-arch arm64 -target arm64-apple-macosx -march=armv8-a+crc+crypto -mcpu=generic"
           --enable-cross-compile
           --enable-pic
           VAREOF

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -398,12 +398,11 @@ jobs:
           elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} == "aarch64" ]]; then
           export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
           export CXXFLAGS="-std=c++11 ${CFLAGS}"
-          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target arm64-apple-macosx -lc++"
+          export LDFLAGS="-arch arm64 -march=armv8-a+crc+crypto -target ${{ matrix.host }} -lc++"
           extra_configure=$(cat <<VAREOF
           --arch=${{ matrix.arch }}
           --cc=clang
           --cxx=clang++
-          --ar=ar
           --target-os=darwin
           --enable-cross-compile
           --disable-neon

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -349,7 +349,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::make"
-          PATH="$root_path/bin:$PATH" make -j $(sysctl -n hw.logicalcpu)
+          PATH="$root_path/bin:$PATH" make -j$(nproc || sysctl -n hw.logicalcpu)
           echo "::endgroup::"
 
           echo "::group::make install"
@@ -432,7 +432,7 @@ jobs:
             --enable-encoder=libx264,libx265 \
             --enable-gpl \
             --enable-libx264 \
-            --enable-libx265
+            --enable-libx265 \
             --enable-static \
             --enable-swscale \
             --pkg-config=pkg-config \


### PR DESCRIPTION
## Description
Adds support for ARM on macOS. Note: neon has been disabled for FFmpeg which will likely make x265 (even more) unusable for this processor, but VideoToolbox hw encode should always be available.

### Issues Fixed or Closed
N/A - prereq for sunshine mac arm support


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [X] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
