### PR TITLE
create pr against sunshine

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -572,7 +572,9 @@ jobs:
           echo "::endgroup::"
 
       - name: Commit build
-        if: ${{ github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}  # yamllint disable-line rule:line-length
+        if: >-
+          github.ref == 'refs/heads/master' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions-js/push@v1.4
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
@@ -582,3 +584,86 @@ jobs:
           branch: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
           force: false
           message: update-${{ steps.date.outputs.date }}
+
+  update_sunshine:
+    if: >-
+      startsWith(github.repository, 'LizardByte/') &&
+      github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [ffmpeg]
+    env:
+      update_branch: update/ffmpeg-submodules
+      submodule_dir: third-party
+    steps:
+
+      - name: Checkout Sunshine
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository_owner }}/Sunshine
+          ref: nightly
+          submodules: recursive
+          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
+          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
+
+      - name: Update submodules
+        run: |
+          # list of submodules
+          SUBMODULES=$(cat <<- VAREOF
+            ffmpeg-linux-aarch64
+            ffmpeg-linux-x86_64
+            ffmpeg-macos-aarch64
+            ffmpeg-macos-x86_64
+            ffmpeg-windows-x86_64
+          VAREOF
+          )
+
+          echo "::group::git checkout"
+          git branch -d ${{ env.update_branch }} || true
+          git checkout -b ${{ env.update_branch }}
+          echo "::endgroup::"
+
+          echo "::group::update submodules"
+          for SUBMODULE in ${SUBMODULES}; do
+            # add submodules if it doesn't exist or update it
+            git submodule add -b ${SUBMODULE} --name ${SUBMODULE} \
+              ${{ github.event.repository.svn_url }} ${{ env.submodule_dir }}/${SUBMODULE} || \
+            git submodule update --remote ${{ env.submodule_dir }}/${SUBMODULE}
+          done
+          echo "::endgroup::"
+
+      - name: git diff
+        id: git_diff
+        run: |
+          echo "git_diff=$(git diff)" >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        # this if statement is probably useless as it will not push if working tree is clean
+        if: ${{ steps.git_diff.outputs.git_diff != '' }}  # does not match nightly
+        uses: actions-js/push@v1.4
+        with:
+          repository: ${{ github.repository_owner }}/Sunshine
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          author_email: ${{ secrets.GH_BOT_EMAIL }}
+          author_name: ${{ secrets.GH_BOT_NAME }}
+          directory: .
+          branch: ${{ env.update_branch }}
+          force: true
+          message: Bump ffmpeg
+
+      - name: Create Pull Request
+        if: ${{ steps.git_diff.outputs.git_diff != '' }}  # does not match nightly
+        # uses: repo-sync/pull-request@v2
+        # use this branch temporary to support creating PR against another repo
+        uses: m4heshd/pull-request@third-party-repos
+        with:
+          destination_repository: ${{ github.repository_owner }}/Sunshine
+          source_branch: ${{ env.update_branch }}
+          destination_branch: nightly
+          pr_title: "Bump ffmpeg"
+          pr_body: |
+            Bump ffmpeg with changes from ${{ github.repository }}
+          pr_assignee: ${{ secrets.GH_BOT_NAME }}
+          pr_draft: false
+          pr_label: "dependencies,submodules"
+          pr_allow_empty: false
+          github_token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- create a pr against sunshine
  - This will update all ffmpeg submodules in a single PR, whereas dependabot creates a PR for every submodule branch, which generates a ton of workflow runs for Sunshine. This PR aims to reduce the workflow runs. Additionally it will be much faster to merge the changes into Sunshine as checks will only need to pass on a single PR instead of multiple.

📝 This depends on a fork of an action to enable PRs against another repository. Once this PR is merged, the workflow can be changed back to the original maintainer. https://github.com/repo-sync/pull-request/pull/69

Todo:
- [x] enable only on specific events (i.e. merge to `master`)
- [x] enable job needs
- [x] test that PR is created properly (should run immediately after creating this PR)
- [x] specified PR labels are not added
- [x] do not automerge these PRs -> https://github.com/LizardByte/.github/issues/152


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
