### PR TITLE
Disable AV1 decoder build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -294,6 +294,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="$root_path/ffmpeg_build" \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_APPS=OFF \
+            -DBUILD_DEC=OFF \
             -DENABLE_AVX512=ON \
             -DBUILD_SHARED_LIBS=OFF \
             ..


### PR DESCRIPTION
## Description
Disable AV1 decoder to reduce build time, it is unused. See https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/CMakeLists.txt#L149

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [X] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
