### PR TITLE
QSV encoders

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -253,7 +253,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/*.patch
 
           # Intel patches
-          git apply -v --ignore-whitespace ../../ffmpeg_sources/cartwheel-ffmpeg/patches/*.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/cartwheel-ffmpeg/patches/*.patch
 
       - name: Setup cross compilation
         id: cross

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -249,9 +249,11 @@ jobs:
       - name: patch
         working-directory: ffmpeg_sources/ffmpeg
         run: |
-          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/01-amf-colorspace-v2.patch
-          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-idr-on-amf.patch
-          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
+          # AMD patches
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/*.patch
+
+          # Intel patches
+          git apply -v --ignore-whitespace ../../ffmpeg_sources/cartwheel-ffmpeg/patches/*.patch
 
       - name: Setup cross compilation
         id: cross

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -244,13 +244,9 @@ jobs:
       - name: patch
         working-directory: ffmpeg_sources/ffmpeg
         run: |
-          # AMD patches
-          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/*.patch
-
-          # Intel patches
-          if [[ ${{ matrix.os_type }} == 'windows' ]]; then
-            git apply -v --ignore-whitespace ../../ffmpeg_patches/cartwheel-ffmpeg/patches/*.patch
-          fi
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/01-amf-colorspace-v2.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-idr-on-amf.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
 
       - name: Setup cross compilation
         id: cross

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -34,10 +34,8 @@ jobs:
               --enable-cuda_llvm
               --enable-encoder=h264_amf,hevc_amf
               --enable-encoder=h264_nvenc,hevc_nvenc
-              --enable-encoder=h264_qsv,hevc_qsv,av1_qsv
               --enable-encoder=h264_vaapi,hevc_vaapi
               --enable-ffnvcodec
-              --enable-libmfx
               --enable-nvenc
               --enable-v4l2_m2m
               --enable-vaapi
@@ -191,9 +189,6 @@ jobs:
                 binutils-${{ matrix.host }} \
                 g++-${{ matrix.host }} \
                 gcc-${{ matrix.host }}
-            else
-              sudo apt-get -y install \
-                libmfx-dev
             fi
             echo "::endgroup::"
           elif [[ ${{ matrix.os_type }} == "macos" ]]; then
@@ -253,7 +248,9 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/*.patch
 
           # Intel patches
-          git apply -v --ignore-whitespace ../../ffmpeg_patches/cartwheel-ffmpeg/patches/*.patch
+          if [[ ${{ matrix.os_type }} == 'windows' ]]; then
+            git apply -v --ignore-whitespace ../../ffmpeg_patches/cartwheel-ffmpeg/patches/*.patch
+          fi
 
       - name: Setup cross compilation
         id: cross

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -34,8 +34,10 @@ jobs:
               --enable-cuda_llvm
               --enable-encoder=h264_amf,hevc_amf
               --enable-encoder=h264_nvenc,hevc_nvenc
+              --enable-encoder=h264_qsv,hevc_qsv,av1_qsv
               --enable-encoder=h264_vaapi,hevc_vaapi
               --enable-ffnvcodec
+              --enable-libmfx
               --enable-nvenc
               --enable-v4l2_m2m
               --enable-vaapi
@@ -87,7 +89,9 @@ jobs:
               --enable-encoder=h264_amf,hevc_amf
               --enable-encoder=h264_mf,hevc_mf
               --enable-encoder=h264_nvenc,hevc_nvenc
+              --enable-encoder=h264_qsv,hevc_qsv,av1_qsv
               --enable-ffnvcodec
+              --enable-libmfx
               --enable-nvenc
               --enable-mediafoundation
     runs-on: ${{ matrix.os }}
@@ -187,6 +191,9 @@ jobs:
                 binutils-${{ matrix.host }} \
                 g++-${{ matrix.host }} \
                 gcc-${{ matrix.host }}
+            else
+              sudo apt-get -y install \
+                libmfx-dev
             fi
             echo "::endgroup::"
           elif [[ ${{ matrix.os_type }} == "macos" ]]; then
@@ -224,6 +231,7 @@ jobs:
             pkg-config
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-libmfx
             mingw-w64-x86_64-nasm
 
       - name: Initialize Submodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = ffmpeg_sources/SVT-AV1
 	url = https://gitlab.com/AOMediaCodec/SVT-AV1.git
 	branch = master
+[submodule "ffmpeg_patches/cartwheel-ffmpeg"]
+	path = ffmpeg_patches/cartwheel-ffmpeg
+	url = https://github.com/intel-media-ci/cartwheel-ffmpeg
+	branch = 5.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,3 @@
 	path = ffmpeg_sources/SVT-AV1
 	url = https://gitlab.com/AOMediaCodec/SVT-AV1.git
 	branch = master
-[submodule "ffmpeg_patches/cartwheel-ffmpeg"]
-	path = ffmpeg_patches/cartwheel-ffmpeg
-	url = https://github.com/intel-media-ci/cartwheel-ffmpeg
-	branch = 5.1


### PR DESCRIPTION
## Description
Adds support for quick sync video using libmfx/mediasdk. I don't think we want to link this one statically because:
1) MediaSDK can't be built for Windows without Visual Studio
2) MediaSDK depends on LibVA so we'd also have to start building that - I'd rather not have to hassle with potential incompatibilities across different linux distros
3) oneVPL is right around the corner and undergoing lots of current development. Allowing end users to update their own library could give upcoming improvements with minimal hassle - Intel has been releasing updated Arc drivers 1-2 times/month

### Issues Fixed or Closed
- Supporting change for LizardByte/Sunshine#619

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [X] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
