### PR TITLE
fix create sunshine PR

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -634,11 +634,17 @@ jobs:
       - name: git diff
         id: git_diff
         run: |
-          echo "git_diff=$(git diff)" >> $GITHUB_OUTPUT
+          git_diff=$(git diff)
+
+          if [[ ${git_diff} == "" ]]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit changes
         # this if statement is probably useless as it will not push if working tree is clean
-        if: ${{ steps.git_diff.outputs.git_diff != '' }}  # does not match nightly
+        if: ${{ steps.git_diff.outputs.changed == 'true' }}  # does not match nightly
         uses: actions-js/push@v1.4
         with:
           repository: ${{ github.repository_owner }}/Sunshine
@@ -651,7 +657,7 @@ jobs:
           message: Bump ffmpeg
 
       - name: Create Pull Request
-        if: ${{ steps.git_diff.outputs.git_diff != '' }}  # does not match nightly
+        if: ${{ steps.git_diff.outputs.changed == 'true' }}  # does not match nightly
         # uses: repo-sync/pull-request@v2
         # use this branch temporary to support creating PR against another repo
         uses: m4heshd/pull-request@third-party-repos


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
PR was failing to be created due to issue with `git_diff` output being multiple lines


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
