### PR TITLE
ffmpeg: add low_latency encoder param for mediafoundation

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -244,6 +244,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/01-amf-colorspace-v2.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-idr-on-amf.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
+++ b/ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
@@ -1,0 +1,45 @@
+From bf116dd598b4c134e26d1d24b6bd65bc86687b75 Mon Sep 17 00:00:00 2001
+From: Conn O'Griofa <connogriofa@gmail.com>
+Date: Tue, 3 Jan 2023 17:20:17 +0000
+Subject: [PATCH] mfenc: add low_latency encoder parameter
+
+Implement support for CODECAPI_AVLowLatencyMode property, which is
+useful for live streaming use cases (and cannot be achieved by
+selecting any of the low latency "scenario" encoder presets alone).
+---
+ libavcodec/mfenc.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libavcodec/mfenc.c b/libavcodec/mfenc.c
+index bbe78605a9..5f5cc262f7 100644
+--- a/libavcodec/mfenc.c
++++ b/libavcodec/mfenc.c
+@@ -54,6 +54,7 @@ typedef struct MFContext {
+     int opt_enc_quality;
+     int opt_enc_scenario;
+     int opt_enc_hw;
++    int opt_enc_lowlatency;
+ } MFContext;
+ 
+ static int mf_choose_output_type(AVCodecContext *avctx);
+@@ -704,6 +705,9 @@ static int mf_encv_output_adjust(AVCodecContext *avctx, IMFMediaType *type)
+ 
+         if (c->opt_enc_scenario >= 0)
+             ICodecAPI_SetValue(c->codec_api, &ff_CODECAPI_AVScenarioInfo, FF_VAL_VT_UI4(c->opt_enc_scenario));
++
++        if (c->opt_enc_lowlatency)
++            ICodecAPI_SetValue(c->codec_api, &ff_CODECAPI_AVLowLatencyMode, FF_VAL_VT_UI4(1));
+     }
+ 
+     return 0;
+@@ -1278,6 +1282,7 @@ static const AVOption venc_opts[] = {
+ 
+     {"quality",       "Quality", OFFSET(opt_enc_quality), AV_OPT_TYPE_INT, {.i64 = -1}, -1, 100, VE},
+     {"hw_encoding",   "Force hardware encoding", OFFSET(opt_enc_hw), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, VE},
++    {"low_latency",   "Low latency mode", OFFSET(opt_enc_lowlatency), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, VE},
+     {NULL}
+ };
+ 
+-- 
+2.39.0
+


### PR DESCRIPTION
## Description
Without this codec property enabled, MediaFoundation has noticeable delayed frames.

### Issues Fixed or Closed
Enhancement for https://github.com/LizardByte/Sunshine/pull/681

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
