### PR TITLE
fix sunshine submodule names

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -633,7 +633,7 @@ jobs:
           echo "::group::update submodules"
           for SUBMODULE in ${SUBMODULES}; do
             # add submodules if it doesn't exist or update it
-            git submodule add -b ${SUBMODULE} --name ${SUBMODULE} \
+            git submodule add -b ${SUBMODULE} \
               ${{ github.event.repository.svn_url }} ${{ env.submodule_dir }}/${SUBMODULE} || \
             git submodule update --remote ${{ env.submodule_dir }}/${SUBMODULE}
           done


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes submodule naming issues when creating a PR against Sunshine. See https://github.com/LizardByte/Sunshine/pull/725 for more info.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
