### PR TITLE
pin build runner os versions

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os_type: linux
-            os: ubuntu-20.04  # Pinned until all platforms moved to 22.04
+            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles
@@ -41,7 +41,7 @@ jobs:
               --enable-vaapi
               --enable-vdpau
           - os_type: linux
-            os: ubuntu-22.04
+            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles
@@ -67,7 +67,7 @@ jobs:
               --enable-encoder=h264_videotoolbox,hevc_videotoolbox
               --enable-videotoolbox
           - os_type: macos
-            os: macos-12
+            os: macos-11
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Pin build runner os versions. Sunshine will not build on Ubuntu 20.04 for aarch64 due to ffmpeg being built on 22.04.

It's possible that macOS aarch64 would also not build on macOS < 12.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
