### PR TITLE
Move `repo-sync/pull-request` back to upstream

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -666,9 +666,7 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ steps.git_diff.outputs.changed == 'true' }}  # does not match nightly
-        # uses: repo-sync/pull-request@v2
-        # use this branch temporary to support creating PR against another repo
-        uses: m4heshd/pull-request@third-party-repos
+        uses: repo-sync/pull-request@v2
         with:
           destination_repository: ${{ github.repository_owner }}/Sunshine
           source_branch: ${{ env.update_branch }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Move `repo-sync/pull-request` back to upstream now that https://github.com/repo-sync/pull-request/pull/69 is merged and released.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #57 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
