### PR TITLE
ffmpeg: fix MFX session leak in QSV

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -248,6 +248,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/02-idr-on-amf.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-qsv-session-leak.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/05-qsv-session-leak.patch
+++ b/ffmpeg_patches/ffmpeg/05-qsv-session-leak.patch
@@ -1,0 +1,54 @@
+From a9ec49b4e728009c4bb4a2af7cb80a3c1ce6016c Mon Sep 17 00:00:00 2001
+From: Cameron Gutman <aicommander@gmail.com>
+Date: Thu, 12 Jan 2023 17:49:29 -0600
+Subject: [PATCH] lavu/hwcontext_qsv: fix MFX session leak in hwdevice
+
+There was no device_uninit() implementation to handle freeing
+the resources allocated in qsv_device_derive_from_child().
+---
+ libavutil/hwcontext_qsv.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
+index 56dffa1f25..504d4f8a45 100644
+--- a/libavutil/hwcontext_qsv.c
++++ b/libavutil/hwcontext_qsv.c
+@@ -220,6 +220,14 @@ static int qsv_fill_border(AVFrame *dst, const AVFrame *src)
+     return 0;
+ }
+ 
++static void qsv_device_uninit(AVHWDeviceContext *ctx)
++{
++    AVQSVDeviceContext *hwctx = ctx->hwctx;
++
++    if (hwctx->session)
++        MFXClose(hwctx->session);
++}
++
+ static int qsv_device_init(AVHWDeviceContext *ctx)
+ {
+     AVQSVDeviceContext *hwctx = ctx->hwctx;
+@@ -1424,11 +1432,7 @@ static int qsv_frames_get_constraints(AVHWDeviceContext *ctx,
+ 
+ static void qsv_device_free(AVHWDeviceContext *ctx)
+ {
+-    AVQSVDeviceContext *hwctx = ctx->hwctx;
+-    QSVDevicePriv       *priv = ctx->user_opaque;
+-
+-    if (hwctx->session)
+-        MFXClose(hwctx->session);
++    QSVDevicePriv *priv = ctx->user_opaque;
+ 
+     av_buffer_unref(&priv->child_device_ctx);
+     av_freep(&priv);
+@@ -1674,6 +1678,7 @@ const HWContextType ff_hwcontext_type_qsv = {
+     .device_create          = qsv_device_create,
+     .device_derive          = qsv_device_derive,
+     .device_init            = qsv_device_init,
++    .device_uninit          = qsv_device_uninit,
+     .frames_get_constraints = qsv_frames_get_constraints,
+     .frames_init            = qsv_frames_init,
+     .frames_uninit          = qsv_frames_uninit,
+-- 
+2.39.0.windows.2
+


### PR DESCRIPTION
## Description
This fixes a bug in the QSV hwdevice context that causes MFX sessions (and thus the ID3D11Device and associated resources) to be leaked every time we open an encoder session.

This can't go upstream as-is due to conflicting changes in FFmpeg master, but I plan to submit a patch upstream too.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
