### PR TITLE
Build ffmpeg against 22.04

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - os_type: linux
-            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
+            os: ubuntu-22.04
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles
@@ -43,7 +43,7 @@ jobs:
               --enable-vaapi
               --enable-vdpau
           - os_type: linux
-            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
+            os: ubuntu-22.04
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles


### PR DESCRIPTION
## Description
Build ffmpeg against 22.04, allowing improved latency reduction for VAAPI encoders supporting `vaSyncBuffer()` interface.

Requires https://github.com/LizardByte/Sunshine/pull/886 to fix linking issue on Ubuntu 20.04 (or other distributions using libva <2.9.0).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
