### PR TITLE
Build ffmpeg with vaSyncBuffer support

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -146,6 +146,13 @@ jobs:
 
           if [[ ${{ matrix.os_type }} == "linux" ]]; then
             echo "::group::linux dependencies"
+
+            if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
+              # activate mesa backport PPA to ensure ffmpeg builds with vaSyncBuffer()
+              # (via libva 2.9.0 or later)
+              sudo add-apt-repository ppa:kisak/turtle -y
+            fi
+
             if [[ $package_arch != "amd64" ]]; then
               # fix original sources
               sudo sed -i -e "s#deb http#deb [arch=amd64] http#g" /etc/apt/sources.list


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->

Use kisak mesa-stable PPA to upgrade libva-dev with support for vaSyncBuffer, allowing lower latency to be achieved on Sunshine builds targeting 22.04+.

This will produce an undefined symbol error on a vanilla 20.04 installation, but that can be worked around via a stub function in Sunshine itself.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
