### PR TITLE
Add h264_v4l2m2m hardware encoder support

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -35,6 +35,7 @@ jobs:
               --enable-encoder=h264_amf,hevc_amf
               --enable-encoder=h264_nvenc,hevc_nvenc
               --enable-encoder=h264_vaapi,hevc_vaapi
+              --enable-encoder=h264_v4l2m2m
               --enable-encoder=h264_qsv,hevc_qsv,av1_qsv
               --enable-ffnvcodec
               --enable-libmfx
@@ -55,6 +56,7 @@ jobs:
               --enable-encoder=h264_amf,hevc_amf
               --enable-encoder=h264_nvenc,hevc_nvenc
               --enable-encoder=h264_vaapi,hevc_vaapi
+              --enable-encoder=h264_v4l2m2m
               --enable-ffnvcodec
               --enable-nvenc
               --enable-v4l2_m2m


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add support for the H.264 Video4Linux2 Memory to Memory encoder for the aarch64 and x86_64 linux versions.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
