### PR TITLE
ci: remove nightly branch

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -3,7 +3,7 @@ name: Build ffmpeg
 
 on:
   pull_request:
-    branches: [master, nightly]
+    branches: [master]
     types: [opened, synchronize, reopened]
   push:
     branches: [master]
@@ -673,7 +673,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/Sunshine
-          ref: nightly
           submodules: recursive
           persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
           fetch-depth: 0  # otherwise, will fail to push refs to dest repo
@@ -718,7 +717,7 @@ jobs:
 
       - name: Commit changes
         # this if statement is probably useless as it will not push if working tree is clean
-        if: ${{ steps.git_diff.outputs.changed == 'true' }}  # does not match nightly
+        if: ${{ steps.git_diff.outputs.changed == 'true' }}
         uses: actions-js/push@v1.4
         with:
           repository: ${{ github.repository_owner }}/Sunshine
@@ -730,13 +729,14 @@ jobs:
           force: true
           message: Bump ffmpeg
 
+      # todo - this action is archived, they recommend using gh cli
       - name: Create Pull Request
-        if: ${{ steps.git_diff.outputs.changed == 'true' }}  # does not match nightly
+        if: ${{ steps.git_diff.outputs.changed == 'true' }}
         uses: repo-sync/pull-request@v2
         with:
           destination_repository: ${{ github.repository_owner }}/Sunshine
           source_branch: ${{ env.update_branch }}
-          destination_branch: nightly
+          destination_branch: nightly  # todo - change to master after default branch is changed in Sunshine
           pr_title: "Bump ffmpeg"
           pr_body: |
             Bump ffmpeg with changes from ${{ github.repository }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR removes `nightly` branch from pull request events. Additionally, it will now use the default Sunshine branch when checking out to prepare the PR.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
