### PR TITLE
fix! use single dist branch

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -619,7 +619,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
+          name: ${{ matrix.os_type }}-${{ matrix.arch }}
           path: |
             ./ffmpeg_build/
 
@@ -646,6 +646,7 @@ jobs:
 
       - name: Commit build
         if: >-
+          startsWith(github.repository, 'LizardByte/') &&
           github.ref == 'refs/heads/master' &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions-js/push@v1.4
@@ -658,90 +659,41 @@ jobs:
           force: false
           message: update-${{ steps.date.outputs.date }}
 
-  update_sunshine:
-    if: >-
-      startsWith(github.repository, 'LizardByte/') &&
-      github.ref == 'refs/heads/master' && github.event_name == 'push'
+  update_dist:
+    # only make the commit conditional, so the rest of the job can be verified on PRs
+    name: Update dist
+    needs: ffmpeg
     runs-on: ubuntu-latest
-    needs: [ffmpeg]
-    env:
-      update_branch: update/ffmpeg-submodules
-      submodule_dir: third-party
-    steps:
 
-      - name: Checkout Sunshine
+    steps:
+      - name: Checkout dist
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.repository_owner }}/Sunshine
-          submodules: recursive
+          ref: dist
+          path: dist
           persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
           fetch-depth: 0  # otherwise, will fail to push refs to dest repo
 
-      - name: Update submodules
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/ffmpeg
+
+      - name: Debug
         run: |
-          # list of submodules
-          SUBMODULES=$(cat <<- VAREOF
-            ffmpeg-linux-aarch64
-            ffmpeg-linux-powerpc64le
-            ffmpeg-linux-x86_64
-            ffmpeg-macos-aarch64
-            ffmpeg-macos-x86_64
-            ffmpeg-windows-x86_64
-          VAREOF
-          )
+          ls -R dist/ffmpeg
 
-          echo "::group::git checkout"
-          git branch -d ${{ env.update_branch }} || true
-          git checkout -b ${{ env.update_branch }}
-          echo "::endgroup::"
-
-          echo "::group::update submodules"
-          for SUBMODULE in ${SUBMODULES}; do
-            # add submodules if it doesn't exist or update it
-            git submodule add -b ${SUBMODULE} \
-              ${{ github.event.repository.svn_url }} ${{ env.submodule_dir }}/${SUBMODULE} || \
-            git submodule update --remote ${{ env.submodule_dir }}/${SUBMODULE}
-          done
-          echo "::endgroup::"
-
-      - name: git diff
-        id: git_diff
-        run: |
-          git_diff=$(git diff)
-
-          if [[ ${git_diff} == "" ]]; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit changes
-        # this if statement is probably useless as it will not push if working tree is clean
-        if: ${{ steps.git_diff.outputs.changed == 'true' }}
+      - name: Commit dist
+        if: >-
+          startsWith(github.repository, 'LizardByte/') &&
+          github.ref == 'refs/heads/master' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions-js/push@v1.4
         with:
-          repository: ${{ github.repository_owner }}/Sunshine
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           author_email: ${{ secrets.GH_BOT_EMAIL }}
           author_name: ${{ secrets.GH_BOT_NAME }}
-          directory: .
-          branch: ${{ env.update_branch }}
-          force: true
-          message: Bump ffmpeg
-
-      # todo - this action is archived, they recommend using gh cli
-      - name: Create Pull Request
-        if: ${{ steps.git_diff.outputs.changed == 'true' }}
-        uses: repo-sync/pull-request@v2
-        with:
-          destination_repository: ${{ github.repository_owner }}/Sunshine
-          source_branch: ${{ env.update_branch }}
-          destination_branch: nightly  # todo - change to master after default branch is changed in Sunshine
-          pr_title: "Bump ffmpeg"
-          pr_body: |
-            Bump ffmpeg with changes from ${{ github.repository }}
-          pr_assignee: ${{ secrets.GH_BOT_NAME }}
-          pr_draft: false
-          pr_label: "dependencies,submodules"
-          pr_allow_empty: false
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          directory: dist
+          branch: dist
+          force: false
+          message: "Commit ${{ github.sha }}"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR modifies the workflow to upload all artifacts to a single `dist` branch. This is due to how submodules are pulled, which is that they download the entire git repo instead of only the branch we specified. This results in pulling 6x as much data as necessary.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
