### PR TITLE
fix: cross-compiling and don't treat x86 as the default case

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -340,24 +340,18 @@ jobs:
           CCPREFIX: ${{ steps.cross.outputs.CCPREFIX }}
         run: |
           echo "::group::configure extra flags for cross compilation"
-          extra_configure=""
           if [[ ${{ matrix.arch }} != "x86_64" ]]; then
             if [[ ${{ matrix.os_type }} == "macos" ]]; then
               export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
               export CXXFLAGS="${{ steps.cross.outputs.CXXFLAGS }}"
               export LDFLAGS="${{ steps.cross.outputs.LDFLAGS }}"
             fi
-            extra_configure=$(cat <<- VAREOF
-              -DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }}
-          VAREOF
-          )
           fi
-          echo "$extra_configure"
           echo "::endgroup::"
 
           echo "::group::configure"
           PATH="$root_path/bin:$PATH" cmake -G "${{ matrix.cmake_generator }}" \
-            $extra_configure \
+            -DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }} \
             -DCMAKE_INSTALL_PREFIX="$root_path/ffmpeg_build" \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_APPS=OFF \
@@ -430,21 +424,15 @@ jobs:
         working-directory: ffmpeg_sources/x265_git
         run: |
           echo "::group::configure extra flags for cross compilation"
-
-          # not currently supported in `aarch64`
-          extra_configure="-DENABLE_HDR10_PLUS=1"
-          if [[ ${{ matrix.os_type }} == "linux" && ${{ matrix.arch }} != "x86_64" ]]; then
-            if [[ ${{ matrix.arch }} == "powerpc64le" ]]; then
-              extra_configure="-DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }}"
-            else
-              extra_configure="-DCMAKE_TOOLCHAIN_FILE=build/${{ matrix.arch }}-${{ matrix.os_type }}/crosscompile.cmake"
-            fi
-          elif [[ ${{ matrix.os_type }} == "macos" && ${{ matrix.arch }} != "x86_64" ]]; then
+          extra_configure=""
+          if [[ ${{ matrix.arch }} == "x86_64" ]]; then
+            # not currently supported in `aarch64`
+            extra_configure="-DENABLE_HDR10_PLUS=1"
+          elif [[ ${{ matrix.os_type }} == "macos" ]]; then
             export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
             export CXXFLAGS="${{ steps.cross.outputs.CXXFLAGS }}"
             extra_configure=$(cat <<- VAREOF
               -DENABLE_ASSEMBLY=0
-              -DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }}
           VAREOF
           )
           fi
@@ -454,6 +442,7 @@ jobs:
           echo "::group::configure"
           PATH="$root_path/bin:$PATH" cmake -G "${{ matrix.cmake_generator }}" \
             $extra_configure \
+            -DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }} \
             -DCMAKE_INSTALL_PREFIX="$root_path/ffmpeg_build" \
             -DENABLE_CLI=OFF \
             -DENABLE_SHARED=OFF \
@@ -586,24 +575,21 @@ jobs:
           cd build
 
           echo "::group::configure extra flags for cross compilation"
-          extra_configure=""
-          if [[ ${{ matrix.arch }} != "x86_64" ]]; then
-            if [[ ${{ matrix.os_type }} == "macos" ]]; then
+          if [[ ${{ matrix.os_type }} == "macos" ]]; then
+            if [[ ${{ matrix.arch }} == "x86_64" ]]; then
+              export CC="gcc"
+              export CXX="g++"
+            else
               export CFLAGS="${{ steps.cross.outputs.CFLAGS }}"
               export CXXFLAGS="${{ steps.cross.outputs.CXXFLAGS }}"
               export LDFLAGS="${{ steps.cross.outputs.LDFLAGS }}"
             fi
-            extra_configure=$(cat <<- VAREOF
-              -DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }}
-          VAREOF
-          )
           fi
-          echo "$extra_configure"
           echo "::endgroup::"
 
           echo "::group::configure"
           PATH="$root_path/bin:$PATH" cmake -G "${{ matrix.cmake_generator }}" \
-            $extra_configure \
+            -DCMAKE_TOOLCHAIN_FILE=${{ steps.cross.outputs.CMAKE_TOOLCHAIN_FILE }} \
             -DCMAKE_INSTALL_PREFIX="$root_path/ffmpeg_build" \
             -DFFMPEG_CBS=ON \
             ..

--- a/cmake/ffmpeg_cbs.cmake
+++ b/cmake/ffmpeg_cbs.cmake
@@ -30,23 +30,30 @@ if (WIN32)
     set(LEADING_SH_COMMAND sh)
 endif ()
 
-if (CROSS_COMPILE_ARM)
-    set(FFMPEG_EXTRA_CONFIGURE
-            --arch=aarch64
-            --enable-cross-compile)
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} arch)
+
+if (${arch} STREQUAL "aarch64" OR ${arch} STREQUAL "arm64")
     set(CBS_ARCH_PATH arm)
-elseif (CROSS_COMPILE_PPC)
-    set(FFMPEG_EXTRA_CONFIGURE
-            --arch=powerpc64le
-            --enable-cross-compile)
+elseif (${arch} STREQUAL "ppc64le")
     set(CBS_ARCH_PATH ppc)
-else ()
+elseif (${arch} STREQUAL "amd64" OR ${arch} STREQUAL "x86_64")
     set(CBS_ARCH_PATH x86)
+else ()
+    message(FATAL_ERROR "Unsupported system processor:" ${CMAKE_SYSTEM_PROCESSOR})
+endif ()
+
+if (CMAKE_CROSSCOMPILING)
+    set(FFMPEG_EXTRA_CONFIGURE --arch=${arch} --enable-cross-compile)
 endif ()
 
 # The generated config.h needs to have `CONFIG_CBS_` flags enabled (from `--enable-bsfs`)
 execute_process(
         COMMAND ${LEADING_SH_COMMAND} ./configure
+            --cc=${CMAKE_C_COMPILER}
+            --cxx=${CMAKE_CXX_COMPILER}
+            --ar=${CMAKE_AR}
+            --ranlib=${CMAKE_RANLIB}
+            --optflags=${CMAKE_C_FLAGS}
             --disable-all
             --disable-autodetect
             --disable-iconv

--- a/cmake/toolchain/aarch64-linux/crosscompile.cmake
+++ b/cmake/toolchain/aarch64-linux/crosscompile.cmake
@@ -1,6 +1,5 @@
 # CMake toolchain file for cross compiling to linux aarch64
 
-set(CROSS_COMPILE_ARM 1)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 

--- a/cmake/toolchain/aarch64-macos/crosscompile.cmake
+++ b/cmake/toolchain/aarch64-macos/crosscompile.cmake
@@ -1,6 +1,5 @@
 # CMake toolchain file for cross compiling to linux aarch64
 
-set(CROSS_COMPILE_ARM 1)
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR arm64)
 set(CMAKE_OSX_ARCHITECTURES arm64)

--- a/cmake/toolchain/powerpc64le-linux/crosscompile.cmake
+++ b/cmake/toolchain/powerpc64le-linux/crosscompile.cmake
@@ -1,6 +1,5 @@
 # CMake toolchain file for cross compiling to linux powerpc64le
 
-set(CROSS_COMPILE_PPC 1)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR ppc64le)
 


### PR DESCRIPTION
## Description
If you set arch-specific `CFLAGS`, then ffmpeg's configure script may fail when it tries to use these flags against the build host's compiler.

Also use `CMAKE_SYSTEM_PROCESSOR` to set up cross-compiling without relying on any custom variables. ffmpeg normalises its `--arch` option and will accept just about any string that you'll likely throw at it.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
