### PR TITLE
Enabled AC3,EAC3 and SWR

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -547,6 +547,7 @@ jobs:
             --disable-autodetect \
             --disable-iconv \
             --enable-avcodec \
+            --enable-encoder=ac3,eac3 \
             --enable-encoder=libsvtav1 \
             --enable-encoder=libx264,libx265 \
             --enable-gpl \
@@ -555,6 +556,7 @@ jobs:
             --enable-libx265 \
             --enable-static \
             --enable-swscale \
+            --enable-swresample \
             --pkg-config=pkg-config \
             ${{ matrix.ffmpeg_extras }} \
             || config_error=true

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -314,6 +314,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-amfenc-new-av1-usages.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/06-prevent-avcodec-dup-symbols.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/06-prevent-avcodec-dup-symbols.patch
+++ b/ffmpeg_patches/ffmpeg/06-prevent-avcodec-dup-symbols.patch
@@ -1,0 +1,31 @@
+Subject: [PATCH] trying to patch ffmpeg
+---
+Index: libavcodec/mf_utils.h
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/libavcodec/mf_utils.h b/libavcodec/mf_utils.h
+--- a/libavcodec/mf_utils.h	(revision 41f32f0bc42490c007920cf7b844f7a84852b201)
++++ b/libavcodec/mf_utils.h	(date 1712917933957)
+@@ -21,20 +21,7 @@
+ 
+ #include <windows.h>
+ #include <initguid.h>
+-#ifdef _MSC_VER
+-// The official way of including codecapi (via dshow.h) makes the ICodecAPI
+-// interface unavailable in UWP mode, but including icodecapi.h + codecapi.h
+-// seems to be equivalent. (These headers conflict with the official way
+-// of including it though, through strmif.h via dshow.h. And on mingw, the
+-// mf*.h headers below indirectly include strmif.h.)
+ #include <icodecapi.h>
+-#else
+-#define NO_DSHOW_STRSAFE
+-#include <dshow.h>
+-// Older versions of mingw-w64 need codecapi.h explicitly included, while newer
+-// ones include it implicitly from dshow.h (via uuids.h).
+-#include <codecapi.h>
+-#endif
+ #include <mfapi.h>
+ #include <mferror.h>
+ #include <mfobjects.h>


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR added AC3, EAC3 encoder to FFMPEG, also swresample for converting PCM format from S16LE to FLTP.

While AC3 has a significantly larger samples per frame (1536 vs 240 currently), it's a compromise because this will be the only way to play 5.1 surround on some platforms.

EAC3 has 256 samples per frame, which is slightly larger than 240 we have now.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
