### PR TITLE
ci!: stop publishing to individual branches

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -622,51 +622,19 @@ jobs:
           make install
           echo "::endgroup::"
 
+      - name: Cleanup
+        run: |
+          rm -f -r ./ffmpeg_build/share
+          rm -f -r ./ffmpeg_build/lib/pkgconfig
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os_type }}-${{ matrix.arch }}
-          path: |
-            ./ffmpeg_build/
-
-      - name: Get current date
-        id: date
-        run: |
-          echo "date=$(date +'%Y-%m-%d')"
-          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Prepare dependency branch
-        run: |
-          echo "::group::cleanup build"
-          rm -f -r ./ffmpeg_build/share
-          rm -f -r ./ffmpeg_build/lib/pkgconfig
-          echo "::endgroup::"
-
-          echo "::group::empty contents"
-          rm -f -r ./ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}/*
-          echo "::endgroup::"
-
-          echo "::group::copy build back to dependency branch"
-          cp -f -r ./ffmpeg_build/. ./ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}/
-          echo "::endgroup::"
-
-      - name: Commit build
-        if: >-
-          startsWith(github.repository, 'LizardByte/') &&
-          github.ref == 'refs/heads/master' &&
-          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions-js/push@v1.5
-        with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          author_email: ${{ secrets.GH_BOT_EMAIL }}
-          author_name: ${{ secrets.GH_BOT_NAME }}
-          directory: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          branch: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          force: false
-          message: update-${{ steps.date.outputs.date }}
+          name: "${{ matrix.os_type }}-${{ matrix.arch }}"
+          path: ./ffmpeg_build/
 
   update_dist:
-    # only make the commit conditional, so the rest of the job can be verified on PRs
+    # only the commit is conditional, so the rest of the job can be verified on PRs
     name: Update dist
     needs: ffmpeg
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
It has been ~5 months since the individual branches have been used as submodules by Sunshine, time to clean up.



### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
