### PR TITLE
ci(windows): unpin binutils

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -274,31 +274,21 @@ jobs:
           fi
 
       - name: Setup Dependencies Windows
+        # if a dependency needs to be pinned, see https://github.com/LizardByte/build-deps/pull/186
         if: ${{ matrix.os_type == 'windows' }}
         uses: msys2/setup-msys2@v2
         with:
           msystem: ucrt64
           update: true
           install: >-
-            wget
-
-      - name: Update Windows dependencies
-        if: ${{ matrix.os_type == 'windows' }}
-        shell: msys2 {0}
-        run: |
-          # download working binutils
-          wget https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-binutils-2.40-4-any.pkg.tar.zst
-
-          # install dependencies
-          pacman -U --noconfirm mingw-w64-ucrt-x86_64-binutils-2.40-4-any.pkg.tar.zst
-          pacman -Syu --noconfirm --ignore=mingw-w64-ucrt-x86_64-binutils \
-            diffutils \
-            git \
-            make \
-            pkg-config \
-            mingw-w64-ucrt-x86_64-cmake \
-            mingw-w64-ucrt-x86_64-gcc \
-            mingw-w64-ucrt-x86_64-onevpl \
+            diffutils
+            git
+            make
+            pkg-config
+            mingw-w64-ucrt-x86_64-binutils
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-onevpl
             mingw-w64-ucrt-x86_64-nasm
 
       - name: Initialize Submodules


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Unpin binutils.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
