### PR TITLE
fix(ci): don't checkout legacy destination branches

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -125,14 +125,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Checkout destination branch
-        uses: actions/checkout@v4
-        with:
-          ref: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          path: ffmpeg-${{ matrix.os_type }}-${{ matrix.arch }}
-          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
-          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
-
       - name: Setup Dependencies Unix
         if: ${{ matrix.os_type != 'windows' }}
         run: |
@@ -239,7 +231,10 @@ jobs:
                 libva-x11-2:$package_arch
             else
               sudo apt-get -y install \
-                libva-dev:$package_arch
+                libva-dev:$package_arch \
+                libva-glx2:$package_arch \
+                libgl1:$package_arch \
+                libglx0:$package_arch
             fi
 
             if [[ ${{ matrix.arch }} != "x86_64" ]]; then


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Don't checkout deleted branches.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
