### PR TITLE
fix(linux): add customized surface alignment patch for VAAPI on AMD

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -308,6 +308,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/03-amfenc-disable-buffering.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-amfenc-new-av1-usages.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/06-vaapi-customized-surface-alignment.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/06-vaapi-customized-surface-alignment.patch
+++ b/ffmpeg_patches/ffmpeg/06-vaapi-customized-surface-alignment.patch
@@ -1,0 +1,79 @@
+From b1cca8de81c1dce44e6eceec376d488a773e5412 Mon Sep 17 00:00:00 2001
+From: Araz Iusubov <primeadvice@gmail.com>
+Date: Thu, 21 Mar 2024 18:02:19 +0100
+Subject: [PATCH] avcodec/vaapi_encode: add customized surface alignment
+
+This commit fixes issues with AMD HEVC encoding.
+By default AMD hevc encoder asks for the alignment 64x16, while FFMPEG VAAPI has 16x16.
+Adding support for customized surface size from VASurfaceAttribAlignmentSize in VAAPI version 1.21.0
+
+Signed-off-by: Araz Iusubov <Primeadvice@gmail.com>
+---
+Suggested-by: Matthew Schwartz <mattschwartz@gwu.edu>
+Pulled from: https://patchwork.ffmpeg.org/project/ffmpeg/patch/20240321170219.1487-1-Primeadvice@gmail.com/
+Context: https://github.com/LizardByte/Sunshine/issues/2636
+---
+ libavcodec/vaapi_encode.c   | 11 +++++++++++
+ libavutil/hwcontext.h       |  7 +++++++
+ libavutil/hwcontext_vaapi.c |  5 +++++
+ 3 files changed, 23 insertions(+)
+
+diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
+index 6c3e41fb31..1856b838b3 100644
+--- a/libavcodec/vaapi_encode.c
++++ b/libavcodec/vaapi_encode.c
+@@ -2714,6 +2714,17 @@ static av_cold int vaapi_encode_create_recon_frames(AVCodecContext *avctx)
+     av_log(avctx, AV_LOG_DEBUG, "Using %s as format of "
+            "reconstructed frames.\n", av_get_pix_fmt_name(recon_format));
+ 
++    if (constraints->log2_alignment) {
++        ctx->surface_width = FFALIGN(avctx->width,
++                              1 << (constraints->log2_alignment & 0xf));
++        ctx->surface_height = FFALIGN(avctx->height,
++                              1 << ((constraints->log2_alignment & 0xf0) >> 4));
++        av_log(avctx, AV_LOG_VERBOSE, "Using customized alignment size "
++                "[%dx%d].\n",
++                (1 << (constraints->log2_alignment & 0xf)),
++                (1 << ((constraints->log2_alignment & 0xf0) >> 4)));
++    }
++
+     if (ctx->surface_width  < constraints->min_width  ||
+         ctx->surface_height < constraints->min_height ||
+         ctx->surface_width  > constraints->max_width ||
+diff --git a/libavutil/hwcontext.h b/libavutil/hwcontext.h
+index 7ff08c8608..fe5d566e75 100644
+--- a/libavutil/hwcontext.h
++++ b/libavutil/hwcontext.h
+@@ -477,6 +477,13 @@ typedef struct AVHWFramesConstraints {
+      */
+     int max_width;
+     int max_height;
++
++    /**
++     * The frame width/height log2 alignment when available
++     * the lower 4 bits, width; another 4 bits, height
++     * (Zero is not applied, use the default value)
++     */
++    int log2_alignment;
+ } AVHWFramesConstraints;
+ 
+ /**
+diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
+index 12bc95119a..98fdb0b764 100644
+--- a/libavutil/hwcontext_vaapi.c
++++ b/libavutil/hwcontext_vaapi.c
+@@ -284,6 +284,11 @@ static int vaapi_frames_get_constraints(AVHWDeviceContext *hwdev,
+             case VASurfaceAttribMaxHeight:
+                 constraints->max_height = attr_list[i].value.value.i;
+                 break;
++#if VA_CHECK_VERSION(1, 21, 0)
++            case VASurfaceAttribAlignmentSize:
++                constraints->log2_alignment = attr_list[i].value.value.i;
++                break;
++#endif
+             }
+         }
+         if (pix_fmt_count == 0) {
+-- 
+2.45.2
+


### PR DESCRIPTION
## Description
Adds a patch to FFmpeg that fixes HEVC VAAPI encoding for AMD cards on Linux and updates the CI to include the patch.

Patch pulled from: https://patchwork.ffmpeg.org/project/ffmpeg/patch/20240321170219.1487-1-Primeadvice@gmail.com/

Tested with sunshine built from [e7c420dd6ee45760d98829a311b35be7dfb118b4](https://github.com/LizardByte/Sunshine/commit/e7c420dd6ee45760d98829a311b35be7dfb118b4) and the resulting build fixes the issue mentioned below with Mesa versions newer than 24.0.4.

### Issues Fixed or Closed
- Closes https://github.com/LizardByte/Sunshine/issues/2636


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [X] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I want maintainers to keep my branch updated
