### PR TITLE
ci(runners): update deprecated runners

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - name: Linux-x86_64  # ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}
             os_type: linux
-            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
+            os: ubuntu-22.04
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles
@@ -43,7 +43,7 @@ jobs:
               --enable-vaapi
           - name: Linux-aarch64
             os_type: linux
-            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
+            os: ubuntu-22.04
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles
@@ -62,7 +62,7 @@ jobs:
               --enable-vaapi
           - name: Linux-ppc64le
             os_type: linux
-            os: ubuntu-20.04  # pinned until all platforms moved to 22.04
+            os: ubuntu-22.04
             arch: powerpc64le
             shell: bash
             cmake_generator: Unix Makefiles
@@ -81,7 +81,7 @@ jobs:
               --enable-vaapi
           - name: Darwin-x86_64
             os_type: macos
-            os: macos-11
+            os: macos-12
             arch: x86_64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
@@ -90,7 +90,7 @@ jobs:
               --enable-videotoolbox
           - name: Darwin-arm64
             os_type: macos
-            os: macos-11
+            os: macos-12
             arch: aarch64
             shell: bash
             cmake_generator: Unix Makefiles  # should be `Xcode` but that fails
@@ -135,6 +135,8 @@ jobs:
             dist="focal"
           elif [[ ${{ matrix.os }} == "ubuntu-22.04" ]]; then
             dist="jammy"
+          elif [[ ${{ matrix.os }} == "ubuntu-24.04" ]]; then
+            dist="noble"
           fi
 
           package_arch="amd64"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- update macOS runners to 12
- update ubuntu runners to 22.04


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
