### PR TITLE
fix(amfenc): stop busy waiting for encoder output

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -309,6 +309,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-amfenc-new-av1-usages.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/06-vaapi-customized-surface-alignment.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/07-amfenc-query-timeout.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/07-amfenc-query-timeout.patch
+++ b/ffmpeg_patches/ffmpeg/07-amfenc-query-timeout.patch
@@ -1,0 +1,53 @@
+From df5d0203200337f9472b729dfb9a1eb9442971c3 Mon Sep 17 00:00:00 2001
+From: Cameron Gutman <aicommander@gmail.com>
+Date: Mon, 2 Sep 2024 16:57:36 -0500
+Subject: [PATCH] amfenc: Use QUERY_TIMEOUT feature to avoid busy looping
+
+---
+ libavcodec/amfenc_av1.c  | 2 ++
+ libavcodec/amfenc_h264.c | 2 ++
+ libavcodec/amfenc_hevc.c | 2 ++
+ 3 files changed, 6 insertions(+)
+
+diff --git a/libavcodec/amfenc_av1.c b/libavcodec/amfenc_av1.c
+index c4e9f45e87..5102db2068 100644
+--- a/libavcodec/amfenc_av1.c
++++ b/libavcodec/amfenc_av1.c
+@@ -196,6 +196,8 @@ FF_ENABLE_DEPRECATION_WARNINGS
+ 
+     AMF_ASSIGN_PROPERTY_RATE(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_FRAMERATE, framerate);
+ 
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_QUERY_TIMEOUT, 50);
++
+     switch (avctx->profile) {
+     case AV_PROFILE_AV1_MAIN:
+         profile = AMF_VIDEO_ENCODER_AV1_PROFILE_MAIN;
+diff --git a/libavcodec/amfenc_h264.c b/libavcodec/amfenc_h264.c
+index d3c6f6a10b..d94644bd85 100644
+--- a/libavcodec/amfenc_h264.c
++++ b/libavcodec/amfenc_h264.c
+@@ -225,6 +225,8 @@ FF_ENABLE_DEPRECATION_WARNINGS
+ 
+     AMF_ASSIGN_PROPERTY_RATE(res, ctx->encoder, AMF_VIDEO_ENCODER_FRAMERATE, framerate);
+ 
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_QUERY_TIMEOUT, 50);
++
+     switch (avctx->profile) {
+     case AV_PROFILE_H264_BASELINE:
+         profile = AMF_VIDEO_ENCODER_PROFILE_BASELINE;
+diff --git a/libavcodec/amfenc_hevc.c b/libavcodec/amfenc_hevc.c
+index c0da0f08b2..4b9e419b74 100644
+--- a/libavcodec/amfenc_hevc.c
++++ b/libavcodec/amfenc_hevc.c
+@@ -187,6 +187,8 @@ FF_ENABLE_DEPRECATION_WARNINGS
+ 
+     AMF_ASSIGN_PROPERTY_RATE(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_FRAMERATE, framerate);
+ 
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, 50);
++
+     color_depth = AMF_COLOR_BIT_DEPTH_8;
+     switch (avctx->profile) {
+     case AV_PROFILE_HEVC_MAIN:
+-- 
+2.43.0.windows.1
+


### PR DESCRIPTION
## Description
This adds a patch to use the AMF `QUERY_OUTPUT` encoder feature to avoid busy looping while waiting for encoder output. 

According to my testing with the EncoderLatency sample in the AMF repository, this has no impact to output latency (avg/min/max encoding time in milliseconds):
- OneInOne algorithm, AMF_VIDEO_ENCODER_QUERY_TIMEOUT=0, no sleep in `AMF_REPEAT` case (equivalent to Sunshine today): 1.76/1.47/3.76
- OneInOne algorithm, AMF_VIDEO_ENCODER_QUERY_TIMEOUT=50, no sleep in `AMF_REPEAT` case (equivalent to this PR): 1.74/1.48/3.76

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
