### PR TITLE
fix: patch Vulkan synchronization

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -310,6 +310,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-amfenc-new-av1-usages.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/06-vaapi-customized-surface-alignment.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/07-amfenc-query-timeout.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/08-vulkan-sync-fix.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/08-vulkan-sync-fix.patch
+++ b/ffmpeg_patches/ffmpeg/08-vulkan-sync-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/libavutil/vulkan.c b/libavutil/vulkan.c
+index e9f094261d..7558c1f0f8 100644
+--- a/libavutil/vulkan.c
++++ b/libavutil/vulkan.c
+@@ -724,6 +724,8 @@ int ff_vk_exec_submit(FFVulkanContext *s, FFVkExecContext *e)
+         return AVERROR_EXTERNAL;
+     }
+ 
++    vk->WaitForFences(s->hwctx->act_dev, 1, &e->fence, VK_TRUE, UINT64_MAX);
++
+     for (int i = 0; i < e->sem_sig_val_dst_cnt; i++)
+         *e->sem_sig_val_dst[i] += 1;
+ 


### PR DESCRIPTION
## Description
This is the FFmpeg Vulkan synchronization fix which solves tearing issues on Linux systems. The issue was originally reported in Sunshine ([Screen Tearing/VSync Issue in KDE Plasma Wayland, Gnome Wayland](https://github.com/LizardByte/Sunshine/issues/3189)). The temporary solution was provided in mesa case [VAAPI->Vulkan zero-copy transcoding in FFmpeg causes tearing](https://gitlab.freedesktop.org/mesa/mesa/-/issues/11913) as it is a workaround that can be used till real FFmpeg fix is mainstreamed


### Screenshot
N/A


### Issues Fixed or Closed
- Fixes [#3189 - Sunshine](https://github.com/LizardByte/Sunshine/issues/3189)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
