### PR TITLE
fix(vaapi): fix surface alignment when building with libva <1.21

### DIFF
--- a/ffmpeg_patches/ffmpeg/05-vaapi-customized-surface-alignment.patch
+++ b/ffmpeg_patches/ffmpeg/05-vaapi-customized-surface-alignment.patch
@@ -1,19 +1,23 @@
-From cd047695b40ba317c88977e530a6058b07559701 Mon Sep 17 00:00:00 2001
+From 46b79b10e995b3ee5ba8473dfa28986fdfea5bbc Mon Sep 17 00:00:00 2001
 From: Araz Iusubov <primeadvice@gmail.com>
 Date: Thu, 21 Mar 2024 18:02:19 +0100
-Subject: [PATCH 3/4] avcodec/vaapi_encode: add customized surface alignment
+Subject: [PATCH] avcodec/vaapi_encode: add customized surface alignment
 
 This commit fixes issues with AMD HEVC encoding.
 By default AMD hevc encoder asks for the alignment 64x16, while FFMPEG VAAPI has 16x16.
 Adding support for customized surface size from VASurfaceAttribAlignmentSize in VAAPI version 1.21.0
 
 Signed-off-by: Araz Iusubov <Primeadvice@gmail.com>
-Signed-off-by: Cameron Gutman <aicommander@gmail.com>
+---
+Suggested-by: Matthew Schwartz <mattschwartz@gwu.edu>
+Pulled from: https://patchwork.ffmpeg.org/project/ffmpeg/patch/20240321170219.1487-1-Primeadvice@gmail.com/
+Context: https://github.com/LizardByte/Sunshine/issues/2636
+Support for FFmpeg 7.1 and libva <1.21 by: Cameron Gutman <aicommander@gmail.com>
 ---
  libavcodec/hw_base_encode.c | 11 +++++++++++
  libavutil/hwcontext.h       |  7 +++++++
- libavutil/hwcontext_vaapi.c |  5 +++++
- 3 files changed, 23 insertions(+)
+ libavutil/hwcontext_vaapi.c |  6 ++++++
+ 3 files changed, 24 insertions(+)
 
 diff --git a/libavcodec/hw_base_encode.c b/libavcodec/hw_base_encode.c
 index 7b6ec97d3b..8929e430ed 100644
@@ -56,21 +60,29 @@ index bac30debae..1eb56aff78 100644
  
  /**
 diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
-index 95aa38d9d2..caed5104e5 100644
+index 95aa38d9d2..6e53448e35 100644
 --- a/libavutil/hwcontext_vaapi.c
 +++ b/libavutil/hwcontext_vaapi.c
-@@ -294,6 +294,11 @@ static int vaapi_frames_get_constraints(AVHWDeviceContext *hwdev,
+@@ -60,6 +60,9 @@ typedef HRESULT (WINAPI *PFN_CREATE_DXGI_FACTORY)(REFIID riid, void **ppFactory)
+ #include "pixdesc.h"
+ #include "pixfmt.h"
+ 
++#if !VA_CHECK_VERSION(1, 21, 0)
++#define VASurfaceAttribAlignmentSize 10
++#endif
+ 
+ typedef struct VAAPIDevicePriv {
+ #if HAVE_VAAPI_X11
+@@ -294,6 +297,9 @@ static int vaapi_frames_get_constraints(AVHWDeviceContext *hwdev,
              case VASurfaceAttribMaxHeight:
                  constraints->max_height = attr_list[i].value.value.i;
                  break;
-+#if VA_CHECK_VERSION(1, 21, 0)
 +            case VASurfaceAttribAlignmentSize:
 +                constraints->log2_alignment = attr_list[i].value.value.i;
 +                break;
-+#endif
              }
          }
          if (pix_fmt_count == 0) {
 -- 
-2.45.2.windows.1
+2.46.2
 


### PR DESCRIPTION
## Description
We build FFmpeg with libva 2.14 since we're using Ubuntu 22.04. This means the FFmpeg patch introduced in #335 won't actually work when it's compiled using our GitHub Actions. This PR fixes that by manually defining the `VASurfaceAttribAlignmentSize` enum value that we need if the libva headers are too old.

I also restored the context in the patch that was lost when I rebased it on FFmpeg 7.1.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
https://github.com/LizardByte/Sunshine/issues/2636


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
