### PR TITLE
fix(ffmpeg): revert broken commit from FFmpeg 7.1

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -311,6 +311,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/04-mfenc-lowlatency.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-vaapi-customized-surface-alignment.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/06-amfenc-query-timeout.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/07-avcodec-options-revert.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/07-avcodec-options-revert.patch
+++ b/ffmpeg_patches/ffmpeg/07-avcodec-options-revert.patch
@@ -1,0 +1,50 @@
+From 7d7c4fc8293044a582bed30d93370ae18ac64497 Mon Sep 17 00:00:00 2001
+From: Cameron Gutman <aicommander@gmail.com>
+Date: Fri, 11 Oct 2024 19:34:22 -0500
+Subject: [PATCH] Revert "lavc: Check codec_whitelist early in avcodec_open2()"
+
+This caused a behavior change that broke setting codec-specific options
+that share names with AVCodecContext options.
+
+This reverts commit 7753a9d62725d5bd8313e2d249acbe1c8af79ab1.
+---
+ libavcodec/avcodec.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/avcodec.c b/libavcodec/avcodec.c
+index d1daf47611..d9b0e1246f 100644
+--- a/libavcodec/avcodec.c
++++ b/libavcodec/avcodec.c
+@@ -175,14 +175,6 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+     if (avctx->extradata_size < 0 || avctx->extradata_size >= FF_MAX_EXTRADATA_SIZE)
+         return AVERROR(EINVAL);
+ 
+-    if ((ret = av_opt_set_dict(avctx, options)) < 0)
+-        return ret;
+-
+-    if (avctx->codec_whitelist && av_match_list(codec->name, avctx->codec_whitelist, ',') <= 0) {
+-        av_log(avctx, AV_LOG_ERROR, "Codec (%s) not on whitelist \'%s\'\n", codec->name, avctx->codec_whitelist);
+-        return AVERROR(EINVAL);
+-    }
+-
+     avci = av_codec_is_decoder(codec) ?
+         ff_decode_internal_alloc()    :
+         ff_encode_internal_alloc();
+@@ -216,6 +208,14 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+     } else {
+         avctx->priv_data = NULL;
+     }
++    if ((ret = av_opt_set_dict(avctx, options)) < 0)
++        goto free_and_end;
++
++    if (avctx->codec_whitelist && av_match_list(codec->name, avctx->codec_whitelist, ',') <= 0) {
++        av_log(avctx, AV_LOG_ERROR, "Codec (%s) not on whitelist \'%s\'\n", codec->name, avctx->codec_whitelist);
++        ret = AVERROR(EINVAL);
++        goto free_and_end;
++    }
+ 
+     // only call ff_set_dimensions() for non H.264/VP6F/DXV codecs so as not to overwrite previously setup dimensions
+     if (!(avctx->coded_width && avctx->coded_height && avctx->width && avctx->height &&
+-- 
+2.43.0.windows.1
+


### PR DESCRIPTION
## Description
Reverts a broken commit from FFmpeg 7.1 that caused https://github.com/LizardByte/Sunshine/issues/3273

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
