### PR TITLE
fix(nvenc): allow opt-out of filler data for AV1

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -312,6 +312,7 @@ jobs:
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/05-vaapi-customized-surface-alignment.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/06-amfenc-query-timeout.patch
           git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/07-vaapi-leak.patch
+          git apply -v --ignore-whitespace ../../ffmpeg_patches/ffmpeg/08-nvenc-av1-filler.patch
 
       - name: Setup cross compilation
         id: cross

--- a/ffmpeg_patches/ffmpeg/08-nvenc-av1-filler.patch
+++ b/ffmpeg_patches/ffmpeg/08-nvenc-av1-filler.patch
@@ -1,0 +1,61 @@
+From 405addaa964425852ad3c3457d8c29b70885b01a Mon Sep 17 00:00:00 2001
+From: Cameron Gutman <aicommander@gmail.com>
+Date: Sun, 27 Oct 2024 22:45:07 -0500
+Subject: [PATCH] avcodec/nvenc: add option to skip padding OBUs
+
+Some scenarios (such as game streaming or videoconferencing) may use CBR
+to strictly cap the maximum encoded bitrate, but they don't mind the
+bitrate falling below the target if the encoder doesn't need the
+additional headroom.
+
+Allow users to opt-out of filler data in CBR mode for those usecases
+where it is unwanted.
+
+Signed-off-by: Cameron Gutman <aicommander@gmail.com>
+---
+ libavcodec/nvenc.c     | 2 +-
+ libavcodec/nvenc.h     | 1 +
+ libavcodec/nvenc_av1.c | 2 ++
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/nvenc.c b/libavcodec/nvenc.c
+index 2cce478be0..17dc8ff6ba 100644
+--- a/libavcodec/nvenc.c
++++ b/libavcodec/nvenc.c
+@@ -1521,7 +1521,7 @@ static av_cold int nvenc_setup_av1_config(AVCodecContext *avctx)
+ 
+     av1->idrPeriod = cc->gopLength;
+ 
+-    if (IS_CBR(cc->rcParams.rateControlMode)) {
++    if (ctx->filler_data && IS_CBR(cc->rcParams.rateControlMode)) {
+         av1->enableBitstreamPadding = 1;
+     }
+ 
+diff --git a/libavcodec/nvenc.h b/libavcodec/nvenc.h
+index 0130b99369..da206a5bfb 100644
+--- a/libavcodec/nvenc.h
++++ b/libavcodec/nvenc.h
+@@ -285,6 +285,7 @@ typedef struct NvencContext
+     int lookahead_level;
+     int unidir_b;
+     int split_encode_mode;
++    int filler_data;
+ } NvencContext;
+ 
+ int ff_nvenc_encode_init(AVCodecContext *avctx);
+diff --git a/libavcodec/nvenc_av1.c b/libavcodec/nvenc_av1.c
+index 79253cff66..5764e4214d 100644
+--- a/libavcodec/nvenc_av1.c
++++ b/libavcodec/nvenc_av1.c
+@@ -149,6 +149,8 @@ static const AVOption options[] = {
+                                                             OFFSET(extra_sei),    AV_OPT_TYPE_BOOL,  { .i64 = 1 }, 0, 1, VE },
+     { "a53cc",        "Use A53 Closed Captions (if available)", OFFSET(a53_cc),   AV_OPT_TYPE_BOOL,  { .i64 = 1 }, 0, 1, VE },
+     { "s12m_tc",      "Use timecode (if available)",        OFFSET(s12m_tc),      AV_OPT_TYPE_BOOL,  { .i64 = 1 }, 0, 1, VE },
++    { "filler_data",  "Use filler data to ensure CBR bitrate is strictly adhered to",
++                                                            OFFSET(filler_data),  AV_OPT_TYPE_BOOL,  { .i64 = 1 }, 0, 1, VE },
+ #ifdef NVENC_HAVE_LOOKAHEAD_LEVEL
+     { "lookahead_level", "Specifies the lookahead level. Higher level may improve quality at the expense of performance.",
+                                                             OFFSET(lookahead_level), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, NV_ENC_LOOKAHEAD_LEVEL_AUTOSELECT, VE, .unit = "lookahead_level" },
+-- 
+2.43.0.windows.1
+


### PR DESCRIPTION
## Description
This adds a patch to allow us to opt-out of AV1 padding OBUs for CBR with NVENC. Bitstream padding is a waste of valuable network bandwidth and also causes problems with Qualcomm's (broken) AV1 decoder.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
Reference: https://github.com/LizardByte/Sunshine/issues/3331
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
