### PR TITLE
build(deps): move all submodules to github mirrors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,11 +4,11 @@
 	branch = master
 [submodule "third-party/FFmpeg/x264"]
 	path = third-party/FFmpeg/x264
-	url = https://code.videolan.org/videolan/x264.git
+	url = https://github.com/LizardByte-infrastructure/x264.git
 	branch = stable
 [submodule "third-party/FFmpeg/x265_git"]
 	path = third-party/FFmpeg/x265_git
-	url = https://bitbucket.org/multicoreware/x265_git.git
+	url = https://github.com/LizardByte-infrastructure/x265_git.git
 	branch = Release_3.5
 [submodule "third-party/FFmpeg/nv-codec-headers"]
 	path = third-party/FFmpeg/nv-codec-headers
@@ -20,5 +20,5 @@
 	branch = release/7.1
 [submodule "third-party/FFmpeg/SVT-AV1"]
 	path = third-party/FFmpeg/SVT-AV1
-	url = https://gitlab.com/AOMediaCodec/SVT-AV1.git
+	url = https://github.com/LizardByte-infrastructure/SVT-AV1.git
 	branch = v1.6.0


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR moves all submodules hosted outside of GitHub to mirrors at the LizardByte-infrastructure org.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
