### PR TITLE
build(cmake): make error prominent in GitHub CI

### DIFF
--- a/cmake/apply_git_patch.cmake
+++ b/cmake/apply_git_patch.cmake
@@ -17,7 +17,7 @@ macro(APPLY_GIT_PATCH repo_path patch_path)
 
         if(${SUCCESS} EQUAL 1)
             # We don't stop here because it can happen in case of parallel builds
-            message(WARNING "\nError: failed to apply the patch patch: ${patch_path}\n")
+            message(WARNING "\n::error:: failed to apply the patch patch: ${patch_path}\n")
         endif()
     endif()
 endmacro()


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Using `::error::` or `::warning::` will make the errors prominent in the workflow summaries. Although this will not fail any job.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
