### PR TITLE
revert: ci(build): fix sed replacement in ubuntu sources (#419)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
               echo "$extra_sources" | sudo tee ${source_file} > /dev/null
             else
               # fix original sources
-              sudo sed -i -E 's#^(deb\s+)(http.*)#\1[arch=amd64] \2#g' ${source_file}
+              sudo sed -i -e "s#deb mirror#deb [arch=amd64] mirror#g" ${source_file}
 
               echo "$extra_sources" | sudo tee -a ${source_file} > /dev/null
             fi


### PR DESCRIPTION
## Description

This reverts commit 7b9e52ef2b377ea2d9cc6b8253850aa0e6e6fb21.

It will fix CI build fails on aarch64 and ppc64le target.

CI Fail Link: https://github.com/LizardByte/build-deps/actions/runs/14978334141/job/42076211911
After revert, all thing is OK, CI Passed Link: https://github.com/rbqvq/build-deps/actions/runs/14978879753/job/42077952271

### Screenshot
None

### Issues Fixed or Closed
None

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
