### PR TITLE
ci(freebsd): use all processors for aarch64 vm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,11 +373,35 @@ jobs:
           echo "MSYS2_ROOT=${{ runner.temp }}/msys64" >> $GITHUB_ENV
           cat "${{ runner.temp }}/setup-msys2/msys2.CMD"
 
+      - name: Get submodule history
+        shell: bash
+        run: |
+          # x265.pc will not be installed if their cmake cannot detect the latest tag
+          # SVT-AV1 cannot determine version if the git history is not available
+
+          for repo in "x265_git" "SVT-AV1"; do
+            cd ${GITHUB_WORKSPACE}/third-party/FFmpeg/$repo
+            git fetch --tags --force origin
+          done
+
+      - name: Get Processor Count
+        id: processor_count
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = 'macOS' ]; then
+            PROCESSOR_COUNT=$(sysctl -n hw.ncpu)
+          else
+            PROCESSOR_COUNT=$(nproc)
+          fi
+          echo "PROCESSOR_COUNT=${PROCESSOR_COUNT}" >> $GITHUB_OUTPUT
+          echo "PROCESSOR_COUNT: $PROCESSOR_COUNT"
+
       - name: Setup FreeBSD
         if: startsWith(matrix.shell, 'freebsd')
         uses: vmactions/freebsd-vm@v1.2.1
         with:
           arch: ${{ matrix.arch }}
+          cpu: ${{ steps.processor_count.outputs.PROCESSOR_COUNT }}
           prepare: |
             pkg install -y \
               devel/autoconf \
@@ -440,31 +464,6 @@ jobs:
             echo "CCPREFIX=/usr/bin/${{ matrix.target }}-" >> $GITHUB_ENV
           fi
 
-      - name: Get Processor Count
-        id: processor_count
-        run: |
-          set -e
-          cd $GITHUB_WORKSPACE
-          if [ "${{ runner.os }}" = 'macOS' ]; then
-            PROCESSOR_COUNT=$(sysctl -n hw.ncpu)
-          else
-            PROCESSOR_COUNT=$(nproc)
-          fi
-          echo "PROCESSOR_COUNT=${PROCESSOR_COUNT}" >> $GITHUB_OUTPUT
-          echo "PROCESSOR_COUNT: $PROCESSOR_COUNT"
-
-      - name: Get submodule history
-        run: |
-          set -e
-
-          # x265.pc will not be installed if their cmake cannot detect the latest tag
-          # SVT-AV1 cannot determine version if the git history is not available
-
-          for repo in "x265_git" "SVT-AV1"; do
-            cd $GITHUB_WORKSPACE/third-party/FFmpeg/$repo
-            git fetch --tags --force origin
-          done
-
       - name: Configure
         run: |
           set -e
@@ -508,10 +507,8 @@ jobs:
 
       - name: Debug logs
         if: always()
+        shell: bash
         run: |
-          set -e
-          cd $GITHUB_WORKSPACE
-
           echo "::group::x264 config.log"
           cat ./third-party/FFmpeg/x264/config.log || true
           echo "::endgroup::"
@@ -522,23 +519,17 @@ jobs:
 
       - name: Debug build directory
         if: always()
-        run: |
-          set -e
-          cd $GITHUB_WORKSPACE
-          ls -R ./build
+        shell: bash
+        run: ls -R ./build
 
       - name: Debug build/dist directory
         if: always()
-        run: |
-          set -e
-          cd $GITHUB_WORKSPACE
-          ls -R ./build/dist
+        shell: bash
+        run: ls -R ./build/dist
 
       - name: Cleanup
-        run: |
-          set -e
-          cd $GITHUB_WORKSPACE
-          rm -f -r ./build/dist/share
+        shell: bash
+        run: rm -f -r ./build/dist/share
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The aarch64 FreeBSD vm is only using 2 processors, but should use the same amount as the host provides. Additionally, some steps were re-ordered to not use the VM which will be faster for the aarch64 build.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
