### PR TITLE
fix(ffmpeg): fix vulkan_encode returning success when encode queue is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(BUILD_FFMPEG_X264_PATCHES "Apply FFmpeg x264 patches" ON)
 option(BUILD_FFMPEG_X265 "Build FFmpeg x265" ON)
 option(BUILD_FFMPEG_X265_PATCHES "Apply FFmpeg x265 patches" ON)
 option(BUILD_FFMPEG_VULKAN "Build FFmpeg with Vulkan video encoding support" ON)
+option(BUILD_FFMPEG_VULKAN_PATCHES "Apply FFmpeg Vulkan patches" ON)
 
 # common includes
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/apply_git_patch.cmake)

--- a/cmake/ffmpeg/vulkan.cmake
+++ b/cmake/ffmpeg/vulkan.cmake
@@ -79,3 +79,12 @@ add_dependencies(${CMAKE_PROJECT_NAME} vulkan-loader)
 
 # Add to PKG_CONFIG_PATH for FFmpeg to find
 set(PKG_CONFIG_PATH "${CMAKE_CURRENT_BINARY_DIR_UNIX}/vulkan/lib/pkgconfig:${PKG_CONFIG_PATH}")
+
+# Apply Vulkan patches to FFmpeg source
+if(BUILD_FFMPEG_ALL_PATCHES OR BUILD_FFMPEG_VULKAN_PATCHES)
+    file(GLOB FFMPEG_VULKAN_PATCH_FILES ${CMAKE_CURRENT_SOURCE_DIR}/patches/FFmpeg/FFmpeg/vulkan/*.patch)
+
+    foreach(patch_file ${FFMPEG_VULKAN_PATCH_FILES})
+        APPLY_GIT_PATCH(${FFMPEG_GENERATED_SRC_PATH} ${patch_file})
+    endforeach()
+endif()

--- a/patches/FFmpeg/FFmpeg/vulkan/01-fix-encode-init-error-code.patch
+++ b/patches/FFmpeg/FFmpeg/vulkan/01-fix-encode-init-error-code.patch
@@ -1,0 +1,20 @@
+Fix vulkan_encode returning success when video encode queue is missing
+
+When ff_vk_qf_find() fails to find a video encode queue, the error path
+returns the stale 'err' variable which is 0 from the previous successful
+ff_vk_load_functions() call. This causes avcodec_open2() to report success
+despite the encoder being in a broken state, leading to a SIGSEGV when
+the caller attempts to encode a frame.
+
+diff --git a/libavcodec/vulkan_encode.c b/libavcodec/vulkan_encode.c
+--- a/libavcodec/vulkan_encode.c
++++ b/libavcodec/vulkan_encode.c
+@@ -811,7 +811,7 @@
+     if (!ctx->qf_enc) {
+         av_log(avctx, AV_LOG_ERROR, "Encoding of %s is not supported by this device\n",
+                avcodec_get_name(avctx->codec_id));
+-        return err;
++        return AVERROR(ENOSYS);
+     }
+ 
+     /* Load all properties */


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
When `ff_vk_qf_find()` fails to find a video encode queue (device does not support Vulkan Video encoding for the requested codec), the error path in `vulkan_encode.c` returns the stale `err` variable which is 0 from the previous successful `ff_vk_load_functions()` call.

This causes `avcodec_open2()` to report success despite the encoder being in a broken state (NULL queue context), leading to a SIGSEGV when the caller attempts to encode a frame.

The fix changes `return err;` to `return AVERROR(ENOSYS);` so the error is properly propagated and the caller can fall back to the next available encoder.

Reproduces on GPUs that support Vulkan but lack video encode queue support for a specific codec (e.g. h264).

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
- Fixes https://github.com/LizardByte/Sunshine/issues/4999


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
