### PR TITLE
fix(ffmpeg): fix vulkan encode feedback flags check before capabilities query

### DIFF
--- a/patches/FFmpeg/FFmpeg/vulkan/02-fix-encode-feedback-flags-check-order.patch
+++ b/patches/FFmpeg/FFmpeg/vulkan/02-fix-encode-feedback-flags-check-order.patch
@@ -1,0 +1,41 @@
+Fix encode feedback flags check running before capabilities are queried
+
+The feedback flags check added in 735c84b57f was placed before
+GetPhysicalDeviceVideoCapabilitiesKHR populates enc_caps, so
+supportedEncodeFeedbackFlags is always zero and the check always fails.
+
+Move the check to after the capabilities query where enc_caps is valid.
+
+diff --git a/libavcodec/vulkan_encode.c b/libavcodec/vulkan_encode.c
+--- a/libavcodec/vulkan_encode.c
++++ b/libavcodec/vulkan_encode.c
+@@ -773,14 +773,6 @@
+         return AVERROR(EINVAL);
+     }
+ 
+-    if ((ctx->enc_caps.supportedEncodeFeedbackFlags & feedback_flags) !=
+-        feedback_flags) {
+-        av_log (avctx, AV_LOG_ERROR,
+-                "Driver does not support required encode feedback flags "
+-                "(BUFFER_OFFSET and BYTES_WRITTEN).\n");
+-        return AVERROR(ENOTSUP);
+-    }
+-
+     ctx->base.op = &vulkan_base_encode_ops;
+     ctx->codec = codec;
+ 
+@@ -880,6 +872,14 @@
+         return AVERROR_EXTERNAL;
+     }
+ 
++    if ((ctx->enc_caps.supportedEncodeFeedbackFlags & feedback_flags) !=
++        feedback_flags) {
++        av_log (avctx, AV_LOG_ERROR,
++                "Driver does not support required encode feedback flags "
++                "(BUFFER_OFFSET and BYTES_WRITTEN).\n");
++        return AVERROR(ENOTSUP);
++    }
++
+     err = init_rc(avctx, ctx);
+     if (err < 0)
+         return err;


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
The feedback flags check added in FFmpeg commit `735c84b57f` ("vulkan: fix encode feedback query handling") reads `ctx->enc_caps.supportedEncodeFeedbackFlags` at line 775, but `GetPhysicalDeviceVideoCapabilitiesKHR` does not populate `enc_caps` until line 863. Since the struct is zero-initialized, the bitmask test always fails and all Vulkan encoders (h264_vulkan, hevc_vulkan, av1_vulkan) are broken on every driver:

```
[h264_vulkan @ 0x561bfc4d0140] Driver does not support required encode feedback flags (BUFFER_OFFSET and BYTES_WRITTEN).
```

The patch moves the check to after the capabilities query where `enc_caps` is valid.

Tested with AMD Radeon RX 9070 XT (RADV GFX1201) and AMD Radeon 780M (RADV PHOENIX), Mesa 26.2.0-devel. Both work after the fix.

This bug exists in upstream FFmpeg on both `master` and `release/8.1` — reported as https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/22967.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes