### PR TITLE
feat(FFmpeg): Enable mpeg2 and h263p encoders

### DIFF
--- a/cmake/ffmpeg/ffmpeg.cmake
+++ b/cmake/ffmpeg/ffmpeg.cmake
@@ -46,6 +46,7 @@ list(APPEND FFMPEG_EXTRA_CONFIGURE
         --enable-avutil
         --enable-bsfs  # ensure config.h will have CONFIG_CBS_ flags
         --enable-swscale
+        --enable-encoder=mpeg2video,h263p
 )
 
 if(BUILD_FFMPEG_AMF)
@@ -82,7 +83,7 @@ endif()
 if(BUILD_FFMPEG_LIBVA)
     list(APPEND FFMPEG_EXTRA_CONFIGURE
             --enable-vaapi
-            --enable-encoder=h264_vaapi,hevc_vaapi,av1_vaapi
+            --enable-encoder=h264_vaapi,hevc_vaapi,av1_vaapi,mpeg2_vaapi
     )
 endif()
 if(BUILD_FFMPEG_VULKAN)
@@ -108,7 +109,7 @@ endif()
 if(WIN32)
     list(APPEND FFMPEG_EXTRA_CONFIGURE
             --enable-d3d11va
-            --enable-encoder=h264_qsv,hevc_qsv,av1_qsv
+            --enable-encoder=h264_qsv,hevc_qsv,av1_qsv,mpeg2_qsv
             --enable-libvpl
     )
 elseif(APPLE)


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Update cmake/ffmpeg/ffmpeg.cmake to enable MPEG-2 encoder support across builds: add --enable-encoder=mpeg2video,h263p to the common configure flags, --enable-encoder=mpeg2_vaapi for libva builds, and --enable-encoder=mpeg2_qsv for Windows QSV builds. This ensures MPEG-2 encoding is available for the respective hardware/software backends.

This is an experiment for https://github.com/LizardByte/Moonlight-XboxOG/pull/194

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [x] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
