### PR TITLE
build: enable ProRes VideoToolbox encoder

### DIFF
--- a/cmake/ffmpeg/ffmpeg.cmake
+++ b/cmake/ffmpeg/ffmpeg.cmake
@@ -114,7 +114,7 @@ if(WIN32)
     )
 elseif(APPLE)
     list(APPEND FFMPEG_EXTRA_CONFIGURE
-            --enable-encoder=h264_videotoolbox,hevc_videotoolbox
+            --enable-encoder=h264_videotoolbox,hevc_videotoolbox,prores_videotoolbox
             --enable-videotoolbox
     )
 elseif(FREEBSD)


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description

Adds `prores_videotoolbox` to the comma-separated FFmpeg `--enable-encoder` configure flag in the macOS-specific branch of `cmake/ffmpeg/ffmpeg.cmake`. The encoder is a hardware ProRes encode path that exists in Apple Silicon's media engine but isn't currently being built into the FFmpeg binary shipped to Sunshine. This one-line change enables it.

**One line of impact:**

```diff
 elseif(APPLE)
     list(APPEND FFMPEG_EXTRA_CONFIGURE
-            --enable-encoder=h264_videotoolbox,hevc_videotoolbox
+            --enable-encoder=h264_videotoolbox,hevc_videotoolbox,prores_videotoolbox
             --enable-videotoolbox
     )
```

The flag is macOS-only (inside the `elseif(APPLE)` branch). Linux, Windows, FreeBSD, and Flatpak build paths are entirely unaffected.

### Why this matters

This is the upstream-side dependency of [LizardByte/Sunshine#5192](https://github.com/LizardByte/Sunshine/pull/5192) (experimental ProRes VideoToolbox encoder in Sunshine). The Sunshine PR's encoder probe path enumerates `prores_videotoolbox` via FFmpeg's avcodec; the encoder is silently absent from the FFmpeg binary unless this configure flag is set, which would make the Sunshine probe fail at runtime even though all the plumbing is correct.

The encoder is part of FFmpeg's standard VideoToolbox encoder family alongside the already-enabled `h264_videotoolbox` and `hevc_videotoolbox`. It is conditionally compiled in the FFmpeg source tree iff its name appears in `--enable-encoder`, so this change is opt-in by configure flag, not by code addition. The resulting libavcodec.a grows by a handful of KB; no new third-party dependency is introduced.


### Screenshot

N/A — build configuration change.


### Issues Fixed or Closed



#### Roadmap Issues



## Type of Change
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [x] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
