### PR TITLE
fix(ffmpeg): re-add vulkan encode init error code patch

### DIFF
--- a/patches/FFmpeg/FFmpeg/vulkan/01-fix-encode-init-error-code.patch
+++ b/patches/FFmpeg/FFmpeg/vulkan/01-fix-encode-init-error-code.patch
@@ -1,0 +1,20 @@
+Fix vulkan_encode returning success when video encode queue is missing
+
+When ff_vk_qf_find() fails to find a video encode queue, the error path
+returns the stale 'err' variable which is 0 from the previous successful
+ff_vk_load_functions() call. This causes avcodec_open2() to report success
+despite the encoder being in a broken state, leading to a SIGSEGV when
+the caller attempts to encode a frame.
+
+diff --git a/libavcodec/vulkan_encode.c b/libavcodec/vulkan_encode.c
+--- a/libavcodec/vulkan_encode.c
++++ b/libavcodec/vulkan_encode.c
+@@ -811,7 +811,7 @@
+     if (!ctx->qf_enc) {
+         av_log(avctx, AV_LOG_ERROR, "Encoding of %s is not supported by this device\n",
+                avcodec_get_name(avctx->codec_id));
+-        return err;
++        return AVERROR(ENOSYS);
+     }
+ 
+     /* Load all properties */


### PR DESCRIPTION
## Description

Re-add `01-fix-encode-init-error-code.patch` for vulkan_encode.

The current FFmpeg submodule (`b21e00e`) on `release/8.1` does not include the fix for the stale `err` variable in `ff_vulkan_encode_init()`. When `ff_vk_qf_find()` fails to locate a video encode queue the function returns 0 (success), leaving the encoder in a broken state and causing a SIGSEGV on the first encode attempt.

The patch changes the return value to `AVERROR(ENOSYS)` so callers get a proper error code.

## Type of Change
- **fix**: Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed

### AI Usage
- **None**: No AI tools were used in creating this PR